### PR TITLE
Make sure Home Assistant reconnects to NHC after disconnect

### DIFF
--- a/custom_components/nhc2/nhccoco/const.py
+++ b/custom_components/nhc2/nhccoco/const.py
@@ -68,8 +68,6 @@ INTERNAL_KEY_CALLBACK = 'callbackHolder'
 INTERNAL_KEY_MODELS = 'models'
 INTERNAL_KEY_CLASS = 'class'
 
-CALLBACK_HOLDER_PROP = 'callbackHolder'
-
 MQTT_METHOD_SYSINFO_PUBLISH = 'systeminfo.publish'
 MQTT_METHOD_SYSINFO_PUBLISHED = 'systeminfo.published'
 MQTT_METHOD_DEVICES_LIST = 'devices.list'


### PR DESCRIPTION
Make sure Home Assistant reconnects to NHC after disconnect eg. after network outage or a system upgrade. Previously, you would have to restart Home Assistant to fix this due to an exception being thrown in the disconnect handler.