### PR TITLE
Service to set light brightness

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ This custom component is a spin-off of the hard and excellent work by @filipvh. 
 - Energy Meters
 - Alloff
 
+## Service
+### Set brightness for light
+The integration exposes a service to set the brightness of a light. This can be 
+used to set the brightness without turning the lights on. For instance if you want 
+your lights to have a certain brightness at night.
+
+See Developer Tools → Services → Niko Home Control II: Set brightness for light.
+
+
 ## How to get it running
 
 Note: Make sure you have a recent version of Home Assistant!

--- a/custom_components/nhc2/const.py
+++ b/custom_components/nhc2/const.py
@@ -20,3 +20,7 @@ SUN_BLIND = 'sunblind'
 GATE = 'gate'
 VENETIAN_BLIND = 'venetianblind'
 GARAGE_DOOR = 'garagedoor'
+
+SERVICE_SET_LIGHT_BRIGHTNESS = 'set_light_brightness'
+
+ATTR_LIGHT_BRIGHTNESS = 'light_brightness'

--- a/custom_components/nhc2/light.py
+++ b/custom_components/nhc2/light.py
@@ -1,6 +1,8 @@
 """Support for NHC2 lights."""
 import logging
 
+import voluptuous as vol
+
 from homeassistant.components.light import LightEntity, SUPPORT_BRIGHTNESS, ATTR_BRIGHTNESS
 from homeassistant.helpers import entity_platform
 from homeassistant.exceptions import HomeAssistantError
@@ -9,7 +11,7 @@ from .nhccoco.coco import CoCo
 from .nhccoco.coco_light import CoCoLight
 from .nhccoco.coco_device_class import CoCoDeviceClass
 
-from .const import DOMAIN, KEY_GATEWAY, BRAND, LIGHT
+from .const import DOMAIN, KEY_GATEWAY, BRAND, LIGHT, SERVICE_SET_LIGHT_BRIGHTNESS, ATTR_LIGHT_BRIGHTNESS
 from .helpers import nhc2_entity_processor
 
 KEY_GATEWAY = KEY_GATEWAY
@@ -30,6 +32,15 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                                               KEY_ENTITY,
                                               lambda x: NHC2HassLight(x))
                         )
+
+    platform = entity_platform.async_get_current_platform()
+    platform.async_register_entity_service(
+        SERVICE_SET_LIGHT_BRIGHTNESS,
+        {
+            vol.Required(ATTR_LIGHT_BRIGHTNESS): vol.Range(0, 100)
+        },
+        "_service_set_light_brightness",
+    )
 
 
 class NHC2HassLight(LightEntity):

--- a/custom_components/nhc2/light.py
+++ b/custom_components/nhc2/light.py
@@ -2,6 +2,9 @@
 import logging
 
 from homeassistant.components.light import LightEntity, SUPPORT_BRIGHTNESS, ATTR_BRIGHTNESS
+from homeassistant.helpers import entity_platform
+from homeassistant.exceptions import HomeAssistantError
+
 from .nhccoco.coco import CoCo
 from .nhccoco.coco_light import CoCoLight
 from .nhccoco.coco_device_class import CoCoDeviceClass
@@ -142,3 +145,15 @@ class NHC2HassLight(LightEntity):
         if self._nhc2light.support_brightness:
             return SUPPORT_BRIGHTNESS
         return 0
+
+    async def _service_set_light_brightness(self, light_brightness: int) -> bool:
+        """Service to set brightness."""
+        _LOGGER.debug(f'Service set_light_brightness called: change brightness to {light_brightness} for {self._nhc2light.name}')
+
+        if not self._nhc2light.support_brightness:
+            _LOGGER.error(f'Light {self._nhc2light.name} does not support brightness')
+            raise HomeAssistantError(f'Light {self._nhc2light.name} does not support brightness')
+            return False
+
+        self._nhc2light.set_brightness(light_brightness)
+        return True

--- a/custom_components/nhc2/services.yaml
+++ b/custom_components/nhc2/services.yaml
@@ -1,0 +1,17 @@
+# Describes the format for available Niko Home Control II services
+set_light_brightness:
+  name: Set brightness for light
+  description: Sets the brightness for a light.
+  target:
+    entity:
+      domain: light
+      multiple: true
+  fields:
+    light_brightness:
+      name: Brightness
+      description: The brightness as a percentage.
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 100


### PR DESCRIPTION
**tl;dr**: Expose a service to set the light brightness without turning them on.

At the moment I have a schedule that defines nighttime. When nighttime is active I want some lights to have a specific brightness. Per example: when I wake up at 03:00 to pee (yeah, I'm old) I want the light at 30% instead of blinding me.

In Home Assistant I have used an Automation that uses the trigger "Off → On", and that uses a [service "Light: Turn on"](https://www.home-assistant.io/integrations/light/#service-lightturn_on) that is able to set the brightness.

But the problem is that the light starts with the previous brightness setting, so if the light was 85% before: it will turn on at 85% and dim to the given brightness (eg: 30%). 

You could think that I had to disable "Dimmer memory", but when you do this the default value is 100%. There is probably a way to configure this with conditions and routines in the Nike Home Control programming software but I thought it would be more logical to have this available in Home Assistant.








