### PR TITLE
Removed homeassistant imports from /nhccoco 

### DIFF
--- a/custom_components/nhc2/nhccoco/coco_climate.py
+++ b/custom_components/nhc2/nhccoco/coco_climate.py
@@ -1,17 +1,8 @@
 import logging
 
 from .helpers import status_prop_in_object_is_on, extract_property_definitions, extract_property_value_from_device
-from .const import THERM_PROGRAM, THERM_OVERRULEACTION, THERM_OVERRULESETPOINT, THERM_OVERRULETIME, THERM_ECOSAVE
+from .const import THERM_PROGRAM, THERM_OVERRULEACTION, THERM_OVERRULESETPOINT, THERM_OVERRULETIME, THERM_ECOSAVE, TEMP_CELSIUS, HVAC_MODE_HEAT_COOL
 from .coco_entity import CoCoEntity
-
-from homeassistant.components.climate import (
-    TEMP_CELSIUS,
-    SUPPORT_TARGET_TEMPERATURE,
-    SUPPORT_TARGET_TEMPERATURE_RANGE,
-    SUPPORT_PRESET_MODE, 
-    HVAC_MODE_HEAT,
-    HVAC_MODE_HEAT_COOL
-)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/nhc2/nhccoco/coco_cover.py
+++ b/custom_components/nhc2/nhccoco/coco_cover.py
@@ -1,7 +1,6 @@
 from .coco_entity import CoCoEntity
 from .const import KEY_BASICSTATE, KEY_POSITION, GATE_VALUE_OPEN, GATE_VALUE_CLOSE, GATE_VALUE_TRIGGERED, \
-                   GATE_MOVING, VALUE_OPEN, VALUE_STOP, VALUE_CLOSE, KEY_ACTION, KEY_ALIGNED
-from ..const import GARAGE_DOOR
+                   GATE_MOVING, VALUE_OPEN, VALUE_STOP, VALUE_CLOSE, KEY_ACTION, KEY_ALIGNED, GARAGE_DOOR
 from .helpers import extract_property_value_from_device
 
 import logging

--- a/custom_components/nhc2/nhccoco/const.py
+++ b/custom_components/nhc2/nhccoco/const.py
@@ -54,11 +54,15 @@ GATE_VALUE_TRIGGERED = 'Triggered'
 GATE_MOVING = 'Intermediate'
 KEY_ALIGNED = "Aligned"
 
+GARAGE_DOOR = 'garagedoor'
+
 THERM_PROGRAM = 'Program'
 THERM_OVERRULEACTION = 'OverruleActive'
 THERM_OVERRULESETPOINT = 'OverruleSetpoint'
 THERM_OVERRULETIME = 'OverruleTime'
 THERM_ECOSAVE = 'EcoSave'
+TEMP_CELSIUS = "°C"
+HVAC_MODE_HEAT_COOL = "heat_cool"
 
 ENERGY_REPORT = 'ReportInstantUsage'
 ENERGY_POWER = 'ElectricalPower'


### PR DESCRIPTION
Removed .homeassistant imports from coco_climate.py and coco_cover.py and put the literals in const.py instead. I want to be able to use /nhccoco on its own in a separate local solution for testing/investigation purposes without needing the whole of homeassistant. I would like to help with development & testing of your excellent work.

(FYI I'm an experienced programmer but GitHub is new to me, so apologies in advance if I do anything wrong!)