### PR TITLE
Add paho-mqtt and getmac to dependencies

### DIFF
--- a/custom_components/nhc2/manifest.json
+++ b/custom_components/nhc2/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nhc2",
   "name": "Niko Home Control II",
-  "requirements": [ "paho-mqtt==1.6.1" ],
+  "requirements": [ "paho-mqtt==1.6.1", "getmac==0.8.3" ],
   "config_flow": true,
   "issue_tracker": "https://github.com/joleys/niko-home-control-II",
   "documentation": "https://github.com/joleys/niko-home-control-II/blob/master/README.md",

--- a/custom_components/nhc2/manifest.json
+++ b/custom_components/nhc2/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nhc2",
   "name": "Niko Home Control II",
-  "requirements": [],
+  "requirements": [ "paho-mqtt==1.6.1" ],
   "config_flow": true,
   "issue_tracker": "https://github.com/joleys/niko-home-control-II",
   "documentation": "https://github.com/joleys/niko-home-control-II/blob/master/README.md",


### PR DESCRIPTION
After installing nhc2 on my home assistant installation it wouldn't load because `import paho.mqtt` failed.