### PR TITLE
Fix exception when coco hostname is not known

### DIFF
--- a/custom_components/nhc2/config_flow.py
+++ b/custom_components/nhc2/config_flow.py
@@ -120,8 +120,12 @@ class Nhc2FlowHandler(config_entries.ConfigFlow):
         host_listing = {}
         first = None
         for i, x in enumerate(self._all_cocos):
-            dkey = x[0] if x[3] is None else x[3]
-            host_listing[dkey] = [x[3] + ' (' + x[0] + ')']
+            if x[3] is None:
+                dkey = x[0]
+                host_listing[dkey] = [x[0]]
+            else:
+                dkey = x[3]
+                host_listing[dkey] = [x[3] + ' (' + x[0] + ')']
             if i == 0:
                 first = dkey
         host_listing[KEY_MANUAL] = 'Manual Input'


### PR DESCRIPTION
Component throws an exception when the host of a coco can't be found because it tries to concatenate NoneType with a string.