### PR TITLE
Prepare for the final 2.0 release

### DIFF
--- a/custom_components/nhc2/manifest.json
+++ b/custom_components/nhc2/manifest.json
@@ -6,6 +6,6 @@
   "issue_tracker": "https://github.com/joleys/niko-home-control-II",
   "documentation": "https://github.com/joleys/niko-home-control-II/blob/master/README.md",
   "codeowners": ["@filipvh", "@joleys"],
-  "version": "2023.1.1",
+  "version": "2.0.0",
   "iot_class": "local_push"
 }


### PR DESCRIPTION
Set a version number so we can prepare for the v3.0 release.

My logic behind the `2.0.0` version is:
* v1.0.0 was the code by [@filipvh](https://github.com/filipvh/hass-nhc2).
* v2.0.0 is the code as it is now

# Release notes
I would use the following release notes. These will be shown to the HACS users.

> This release does not include any updates. You can safely upgrade!
> We are preparing for the next major version of this integration.
