### PR TITLE
integrate digital meter(BE)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "*.yaml": "home-assistant"
+    }
+}

--- a/custom_components/nhc2/nhccoco/__init__.py
+++ b/custom_components/nhc2/nhccoco/__init__.py
@@ -7,6 +7,7 @@ from .coco_climate import CoCoThermostat
 from .coco_energy import CoCoEnergyMeter
 from .coco_cover import CoCoCover
 from .coco_accesscontrol import CoCoAccessControl
+from .coco_energy_home import CoCoEnergyHome
 from .coco_device_class import CoCoDeviceClass
 
 __all__ = ["CoCo",
@@ -18,4 +19,5 @@ __all__ = ["CoCo",
            "CoCoEnergyMeter",
            "CoCoCover",
            "CoCoAccessControl",
+           "CocoEnergyHome",
            "CoCoDeviceClass"]

--- a/custom_components/nhc2/nhccoco/coco.py
+++ b/custom_components/nhc2/nhccoco/coco.py
@@ -7,6 +7,8 @@ from typing import Callable
 
 import paho.mqtt.client as mqtt
 
+from .coco_energy_home import CoCoEnergyHome
+
 from .coco_device_class import CoCoDeviceClass
 from .coco_fan import CoCoFan
 from .coco_light import CoCoLight
@@ -38,8 +40,8 @@ DEVICE_SETS = {
     CoCoDeviceClass.ACCESSCONTROL: {INTERNAL_KEY_CLASS: CoCoAccessControl, INTERNAL_KEY_MODELS: LIST_VALID_ACCESSCONTROL},
     CoCoDeviceClass.BUTTONS: {INTERNAL_KEY_CLASS: CoCoButton, INTERNAL_KEY_MODELS: LIST_VALID_BUTTONS},
     CoCoDeviceClass.SMARTPLUGS: {INTERNAL_KEY_CLASS: CoCoSmartPlug, INTERNAL_KEY_MODELS: LIST_VALID_SMARTPLUGS},
-    CoCoDeviceClass.GENERIC: {INTERNAL_KEY_CLASS: CoCoGeneric, INTERNAL_KEY_MODELS: LIST_VALID_GENERICS},
-    CoCoDeviceClass.VIRTUAL: {INTERNAL_KEY_CLASS: CoCoVirtual, INTERNAL_KEY_MODELS: LIST_VALID_VIRTUAL}
+    CoCoDeviceClass.VIRTUAL: {INTERNAL_KEY_CLASS: CoCoVirtual, INTERNAL_KEY_MODELS: LIST_VALID_VIRTUAL},
+    CoCoDeviceClass.ENERGY_HOME: {INTERNAL_KEY_CLASS: CoCoEnergyHome, INTERNAL_KEY_MODELS: LIST_VALID_ENERGY_HOME}
 }
 
 
@@ -209,6 +211,8 @@ class CoCo:
             filter(lambda d: d[KEY_TYPE] == "smartplug", extract_devices(response))))
         actionable_devices.extend(list(
             filter(lambda d: d[KEY_TYPE] == "virtual", extract_devices(response))))
+        actionable_devices.extend(list(
+            filter(lambda d: d[KEY_TYPE] == "energyhome", extract_devices(response))))
 
         # Only prepare for devices that don't already exist
         # TODO - Can't we do this when we need it (in initialize_devices ?)
@@ -219,6 +223,7 @@ class CoCo:
                     {INTERNAL_KEY_CALLBACK: None, KEY_ENTITY: None}
 
         # Initialize
+        self.initialize_devices(CoCoDeviceClass.ENERGY_HOME, actionable_devices)
         self.initialize_devices(CoCoDeviceClass.SWITCHED_FANS, actionable_devices)
         self.initialize_devices(CoCoDeviceClass.FANS, actionable_devices)
         self.initialize_devices(CoCoDeviceClass.SWITCHES, actionable_devices)
@@ -229,7 +234,6 @@ class CoCo:
         self.initialize_devices(CoCoDeviceClass.ACCESSCONTROL, actionable_devices)
         self.initialize_devices(CoCoDeviceClass.BUTTONS, actionable_devices)
         self.initialize_devices(CoCoDeviceClass.SMARTPLUGS, actionable_devices)
-        self.initialize_devices(CoCoDeviceClass.GENERIC, actionable_devices)
         self.initialize_devices(CoCoDeviceClass.VIRTUAL, actionable_devices)
 
     def initialize_devices(self, device_class, actionable_devices):

--- a/custom_components/nhc2/nhccoco/coco_device_class.py
+++ b/custom_components/nhc2/nhccoco/coco_device_class.py
@@ -14,3 +14,4 @@ class CoCoDeviceClass(Enum):
     SMARTPLUGS = 'smartplugs'
     GENERIC = 'generic'
     VIRTUAL = 'virtual'
+    ENERGY_HOME = "energyhome"

--- a/custom_components/nhc2/nhccoco/coco_energy_home.py
+++ b/custom_components/nhc2/nhccoco/coco_energy_home.py
@@ -1,0 +1,47 @@
+from .coco_entity import CoCoEntity
+from .const import (
+    ENERGY_HOME_POWER_FROM_GRID,
+    ENERGY_HOME_POWER_TO_GRID,
+    ENERGY_REPORT,
+)
+from .helpers import extract_property_value_from_device
+
+
+class CoCoEnergyHome(CoCoEntity):
+    def __init__(
+        self,
+        dev,
+        callback_container,
+        client,
+        profile_creation_id,
+        command_device_control,
+    ):
+        super().__init__(
+            dev, callback_container, client, profile_creation_id, command_device_control
+        )
+        self.update_dev(dev, callback_container)
+        self._command_device_control(self._uuid, ENERGY_REPORT, "True")
+
+    def update_dev(self, dev, callback_container=None):
+        has_changed = super().update_dev(dev, callback_container)
+        toGrid = extract_property_value_from_device(dev, ENERGY_HOME_POWER_TO_GRID)
+        fromGrid = extract_property_value_from_device(dev, ENERGY_HOME_POWER_FROM_GRID)
+        if toGrid:
+            self._state = 0 - float(toGrid)
+            has_changed = True
+        if fromGrid:
+            self._state = float(fromGrid)
+            has_changed = True
+        status_value = extract_property_value_from_device(dev, ENERGY_REPORT)
+        if status_value == "False":
+            self._command_device_control(self._uuid, ENERGY_REPORT, "True")
+        return has_changed
+
+    def _update(self, dev):
+        has_changed = self.update_dev(dev)
+        if has_changed:
+            self._state_changed()
+
+    @property
+    def state(self):
+        return self._state

--- a/custom_components/nhc2/nhccoco/const.py
+++ b/custom_components/nhc2/nhccoco/const.py
@@ -21,6 +21,7 @@ LIST_VALID_BUTTONS = ['alloff']
 LIST_VALID_SMARTPLUGS = ['naso']
 LIST_VALID_GENERICS = ['generic']
 LIST_VALID_VIRTUAL = ['flag']
+LIST_VALID_ENERGY_HOME = ['generic']
 
 DEVICE_CONTROL_BUFFER_SIZE = 16
 DEVICE_CONTROL_BUFFER_COMMAND_SIZE = 32
@@ -68,8 +69,10 @@ THERM_ECOSAVE = 'EcoSave'
 TEMP_CELSIUS = "°C"
 HVAC_MODE_HEAT_COOL = "heat_cool"
 
-ENERGY_REPORT = 'ReportInstantUsage'
-ENERGY_POWER = 'ElectricalPower'
+ENERGY_REPORT = "ReportInstantUsage"
+ENERGY_POWER = "ElectricalPower"
+ENERGY_HOME_POWER_TO_GRID = "ElectricalPowerToGrid"
+ENERGY_HOME_POWER_FROM_GRID = "ElectricalPowerFromGrid"
 
 DEV_TYPE_ACTION = 'action'
 

--- a/custom_components/nhc2/sensor.py
+++ b/custom_components/nhc2/sensor.py
@@ -4,6 +4,8 @@ import logging
 from homeassistant.components.sensor import PLATFORM_SCHEMA, STATE_CLASS_MEASUREMENT, SensorEntity
 from homeassistant.const import POWER_WATT, DEVICE_CLASS_POWER
 
+from .nhccoco.coco_energy_home import CoCoEnergyHome
+
 from .nhccoco.coco import CoCo
 from .nhccoco.coco_energy import CoCoEnergyMeter
 from .nhccoco.coco_smartplug import CoCoSmartPlug
@@ -21,6 +23,17 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Load NHC2 energy meters based on a config entry."""
     gateway: CoCo = hass.data[KEY_GATEWAY][config_entry.entry_id]
     _LOGGER.debug('Platform is starting')
+
+    _LOGGER.info("starting energyHome")
+    hass.data.setdefault('nhc2_energyHome', {})[config_entry.entry_id] = []
+    gateway.get_devices(CoCoDeviceClass.ENERGY_HOME,
+                        nhc2_entity_processor(hass,
+                                              config_entry,
+                                              async_add_entities,
+                                              'nhc2_energyHome',
+                                              lambda x: NHC2EnergyHome(x))
+    )
+
     hass.data.setdefault('nhc2_energymeters', {})[config_entry.entry_id] = []
     gateway.get_devices(CoCoDeviceClass.ENERGYMETERS,
                         nhc2_entity_processor(hass,
@@ -116,3 +129,80 @@ class NHC2HassSmartPlug(NHC2HassEnergyMeter):
         data = super().device_info
         data['model'] = SMARTPLUG
         return data
+    
+    def nhc2_update(self, nhc2smartplug: CoCoSmartPlug):
+        self._nhc2smartplug = nhc2smartplug
+        nhc2smartplug.on_change = self._on_change
+        self.schedule_update_ha_state()
+
+class NHC2EnergyHome(SensorEntity):
+    """Representation of an NHC2 Energy Home."""
+
+    def __init__(self, nhc2energyHome: CoCoEnergyHome, optimistic=True):
+        """Initialize an energy meter."""
+        self._nhc2energyHome = nhc2energyHome
+        self._state = self._nhc2energyHome.state
+        nhc2energyHome.on_change = self._on_change
+    
+    def nhc2_update(self, nhc2energyHome: CoCoEnergyHome):
+        """Update the NHC2 EnergyHome with a new object."""
+        self._nhc2energyHome = nhc2energyHome
+        nhc2energyHome.on_change = self._on_change
+        self.schedule_update_ha_state()
+
+    @property
+    def native_unit_of_measurement(self):
+        """Return the unit the value is expressed in."""
+        return POWER_WATT
+
+    @property
+    def device_class(self):
+        """Return the device class the sensor belongs to."""
+        return DEVICE_CLASS_POWER
+
+    @property
+    def state_class(self):
+        """Return the state class the sensor belongs to."""
+        return STATE_CLASS_MEASUREMENT
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    def _on_change(self):
+        self._state = self._nhc2energyHome.state
+        self.schedule_update_ha_state()
+
+    @property
+    def unique_id(self):
+        """Return the energy meters UUID."""
+        return self._nhc2energyHome.uuid
+
+    @property
+    def uuid(self):
+        """Return the energy meters UUID."""
+        return self._nhc2energyHome.uuid
+
+    @property
+    def should_poll(self):
+        """Return false, since the energy meters will push state."""
+        return False
+
+    @property
+    def name(self):
+        """Return the energy meters name."""
+        return self._nhc2energyHome.name
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        return {
+            'identifiers': {
+                (DOMAIN, self.unique_id)
+            },
+            'name': 'energyhome',
+            'manufacturer': BRAND,
+            'model': 'generic',
+            'via_hub': (DOMAIN, self._nhc2energyHome.profile_creation_id),
+        }


### PR DESCRIPTION
Integrate digital meter as a sensor.
My Niko home control 2 is connected to my digital meter's p1 port.

Reading from digital meter will be auto discovered as new sensor entity called "energyhome".

Sorry for my bad coding, since I don't have any experience with Python.. And also new to home automation.

<img width="1420" alt="image" src="https://user-images.githubusercontent.com/20686460/221528763-77134c9e-109b-4ecb-b86b-59f686cb24d4.png">
