### PR TITLE
Convert the value to a string before sending it.

### DIFF
--- a/custom_components/nhc2/nhccoco/devices/motor_action.py
+++ b/custom_components/nhc2/nhccoco/devices/motor_action.py
@@ -82,5 +82,5 @@ class CocoMotorAction(CoCoDevice):
         gateway.add_device_control(
             self.uuid,
             PROPERTY_POSITION,
-            position
+            str(position)
         )


### PR DESCRIPTION
Fixes: https://github.com/joleys/niko-home-control-II/issues/63