### PR TITLE
68 Disable Energy monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ __Remark:__ The totals are not available as they are not (yet) exposed by the AP
   automatically be enabled.
 * **Electrical Power Production Threshold Exceeded Binary Sensor**, this is on when the central meters electrical power
   production is greater than the threshold of 300W (+ 5W hysteresis)
+* **Disable Report Instant Usage Re-enabling Switch**, a toggle to disable the automatic re-enabling of the
+  Report Instant Usage Binary Sensor. This is useful if you don't need Electrical Power reporting.
 
 __Remark:__ There a more properties to this device, but these are not documented so it is difficult to know what they
 report exactly.

--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ This is the energy metering linked to a zigbee smart plug. The smart plug itself
 * **Feedback Enabled Binary Sensor**. On if the feedback led shows the relay status. Off if the feedback led is
   disabled.
 * **Measuring Only Binary Sensor**. If on, the relay will always be on.
+* **Disable Report Instant Usage Re-enabling Switch**, a toggle to disable the automatic re-enabling of the
+  Report Instant Usage property. This is useful if you don't need Electrical Power reporting.
 
 __Remark:__ The totals are not available as they are not (yet) exposed by the API.
 
@@ -287,6 +289,8 @@ This is the energy metering linked to a generic zigbee smart plug. The smart plu
   produced.
 * **Report Instant Usage Binary Sensor**, indicates if the Electrical Power is received. When disabled, it will
   automatically be enabled.
+* **Disable Report Instant Usage Re-enabling Switch**, a toggle to disable the automatic re-enabling of the
+  Report Instant Usage property. This is useful if you don't need Electrical Power reporting.
 
 __Remark:__ The totals are not available as they are not (yet) exposed by the API.
 
@@ -309,6 +313,8 @@ These helpers can be used in the HA Energy Dashboard.
 * **Flow Sensor**, Producer or Consumer
 * **Segment Sensor**, Central or Subsegment
 * **Clamp Type Sensor**, (only if supported), 63A or 120A
+* **Disable Report Instant Usage Re-enabling Switch**, a toggle to disable the automatic re-enabling of the
+  Report Instant Usage property. This is useful if you don't need Electrical Power reporting.
 
 __Remark:__ The totals are not available as they are not (yet) exposed by the API.
 
@@ -330,7 +336,7 @@ __Remark:__ The totals are not available as they are not (yet) exposed by the AP
 * **Electrical Power Production Threshold Exceeded Binary Sensor**, this is on when the central meters electrical power
   production is greater than the threshold of 300W (+ 5W hysteresis)
 * **Disable Report Instant Usage Re-enabling Switch**, a toggle to disable the automatic re-enabling of the
-  Report Instant Usage Binary Sensor. This is useful if you don't need Electrical Power reporting.
+  Report Instant Usage property. This is useful if you don't need Electrical Power reporting.
 
 __Remark:__ There a more properties to this device, but these are not documented so it is difficult to know what they
 report exactly.

--- a/custom_components/nhc2/entities/electricity_clamp_centralmeter_disable_report_instant_usage_re_enabling.py
+++ b/custom_components/nhc2/entities/electricity_clamp_centralmeter_disable_report_instant_usage_re_enabling.py
@@ -1,0 +1,88 @@
+from homeassistant.components.input_boolean import RestoreEntity
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.const import STATE_OFF, STATE_ON
+
+from ..const import DOMAIN, BRAND
+
+from ..nhccoco.devices.electricity_clamp_centralmeter import CocoElectricityClampCentralmeter
+
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Nhc2ElectricityClampCentralmeterDisableReportInstantUsageReEnablingEntity(RestoreEntity):
+    _attr_has_entity_name = True
+
+    def __init__(self, device_instance: CocoElectricityClampCentralmeter, hub, gateway):
+        """Initialize an input boolean."""
+        self._device = device_instance
+        self._hub = hub
+        self._gateway = gateway
+
+        self._device.after_change_callbacks.append(self.on_change)
+
+        self._attr_available = self._device.is_online
+        self._attr_unique_id = device_instance.uuid + '_disable_report_instant_usage_re_enabling'
+        self._attr_should_poll = False
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._attr_device_class = None
+
+        self._state = None
+
+    @property
+    def name(self) -> str:
+        return 'Disable Report Instant Usage Re-enabling'
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        return {
+            'identifiers': {
+                (DOMAIN, self._device.uuid)
+            },
+            'name': self._device.name,
+            'manufacturer': BRAND,
+            'model': str.title(f'{self._device.model} ({self._device.type})'),
+            'via_device': self._hub
+        }
+
+    @property
+    def state(self):
+        if self._state is None:
+            return STATE_OFF
+
+        return self._state
+
+    @property
+    def is_on(self) -> bool:
+        return self._state == STATE_ON
+
+    def on_change(self):
+        pass
+
+    def _start_reporting_if_enabled(self):
+        if not self.is_on:
+            self._device.enable_report_instant_usage(self._gateway)
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        state = await self.async_get_last_state()
+
+        if not state:
+            # Fallback, if no previous state is found, assume it is off
+            self._state = STATE_OFF
+        else:
+            self._state = state.state
+
+        self.async_schedule_update_ha_state(True)
+        self._start_reporting_if_enabled()
+
+    async def async_turn_on(self, **kwargs):
+        self._state = STATE_ON
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs):
+        self._state = STATE_OFF
+        self._start_reporting_if_enabled()
+        self.async_write_ha_state()

--- a/custom_components/nhc2/entities/electricity_clamp_centralmeter_report_instant_usage.py
+++ b/custom_components/nhc2/entities/electricity_clamp_centralmeter_report_instant_usage.py
@@ -1,5 +1,6 @@
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.helpers.entity import EntityCategory
+from homeassistant.const import STATE_ON
 
 from ..const import DOMAIN, BRAND
 
@@ -29,9 +30,6 @@ class Nhc2ElectricityClampCentralmeterReportInstantUsageEntity(BinarySensorEntit
         self._attr_state_class = None
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
-        # Start reporting
-        self._device.enable_report_instant_usage(self._gateway)
-
     @property
     def name(self) -> str:
         return 'Report Instant Usage'
@@ -56,7 +54,23 @@ class Nhc2ElectricityClampCentralmeterReportInstantUsageEntity(BinarySensorEntit
     def on_change(self):
         # Re-enable reporting when it is turned off
         if self._device.is_report_instant_usage is False:
+            if self._is_report_instant_usage_re_enabling_disabled():
+                _LOGGER.debug(f'{self.name} re-enabling disabled')
+                return
+
             _LOGGER.debug(f'{self.name} re-enabled')
             self._device.enable_report_instant_usage(self._gateway)
 
         self.schedule_update_ha_state()
+
+    def _is_report_instant_usage_re_enabling_disabled(self) -> bool:
+        disable_report_instant_usage_re_enabling_entity = self.hass.states.get(
+            self.entity_id.replace('binary_sensor.', 'switch.').replace('_report_instant_usage',
+                                                                        '_disable_report_instant_usage_re_enabling')
+        )
+
+        if disable_report_instant_usage_re_enabling_entity is None:
+            _LOGGER.debug(f'{self.name} no Disable Report Instant Usage Re-enabling entity found.')
+            return False
+
+        return disable_report_instant_usage_re_enabling_entity.state == STATE_ON

--- a/custom_components/nhc2/entities/generic_energyhome_disable_report_instant_usage_re_enabling.py
+++ b/custom_components/nhc2/entities/generic_energyhome_disable_report_instant_usage_re_enabling.py
@@ -70,10 +70,10 @@ class Nhc2GenericEnergyhomeDisableReportInstantUsageReEnablingEntity(RestoreEnti
         state = await self.async_get_last_state()
         if not state:
             # Fallback, if no previous state is found, assume it is off
-            self._start_reporting_if_enabled()
-            return
+            self._state = STATE_OFF
+        else:
+            self._state = state.state
 
-        self._state = state.state
         self.async_schedule_update_ha_state(True)
         self._start_reporting_if_enabled()
 

--- a/custom_components/nhc2/entities/generic_energyhome_disable_report_instant_usage_re_enabling.py
+++ b/custom_components/nhc2/entities/generic_energyhome_disable_report_instant_usage_re_enabling.py
@@ -1,0 +1,87 @@
+from homeassistant.components.input_boolean import RestoreEntity
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.const import STATE_OFF, STATE_ON
+
+from ..const import DOMAIN, BRAND
+
+from ..nhccoco.devices.generic_energyhome import CocoGenericEnergyhome
+
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Nhc2GenericEnergyhomeDisableReportInstantUsageReEnablingEntity(RestoreEntity):
+    _attr_has_entity_name = True
+
+    def __init__(self, device_instance: CocoGenericEnergyhome, hub, gateway):
+        """Initialize an input boolean."""
+        self._device = device_instance
+        self._hub = hub
+        self._gateway = gateway
+
+        self._device.after_change_callbacks.append(self.on_change)
+
+        self._attr_available = self._device.is_online
+        self._attr_unique_id = device_instance.uuid + '_disable_report_instant_usage_re_enabling'
+        self._attr_should_poll = False
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._attr_device_class = None
+
+        self._state = None
+
+    @property
+    def name(self) -> str:
+        return 'Disable Report Instant Usage Re-enabling'
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        return {
+            'identifiers': {
+                (DOMAIN, self._device.uuid)
+            },
+            'name': self._device.name,
+            'manufacturer': BRAND,
+            'model': str.title(f'{self._device.model} ({self._device.type})'),
+            'via_device': self._hub
+        }
+
+    @property
+    def state(self):
+        if self._state is None:
+            return STATE_OFF
+
+        return self._state
+
+    @property
+    def is_on(self) -> bool:
+        return self._state == STATE_ON
+
+    def on_change(self):
+        pass
+
+    def _start_reporting_if_enabled(self):
+        if not self.is_on:
+            self._device.enable_report_instant_usage(self._gateway)
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        state = await self.async_get_last_state()
+        if not state:
+            # Fallback, if no previous state is found, assume it is off
+            self._start_reporting_if_enabled()
+            return
+
+        self._state = state.state
+        self.async_schedule_update_ha_state(True)
+        self._start_reporting_if_enabled()
+
+    async def async_turn_on(self, **kwargs):
+        self._state = STATE_ON
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs):
+        self._state = STATE_OFF
+        self._start_reporting_if_enabled()
+        self.async_write_ha_state()

--- a/custom_components/nhc2/entities/generic_energyhome_report_instant_usage.py
+++ b/custom_components/nhc2/entities/generic_energyhome_report_instant_usage.py
@@ -30,9 +30,6 @@ class Nhc2GenericEnergyhomeReportInstantUsageEntity(BinarySensorEntity):
         self._attr_state_class = None
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
-        # Start reporting
-        self._device.enable_report_instant_usage(self._gateway)
-
     @property
     def name(self) -> str:
         return 'Report Instant Usage'

--- a/custom_components/nhc2/entities/generic_energyhome_report_instant_usage.py
+++ b/custom_components/nhc2/entities/generic_energyhome_report_instant_usage.py
@@ -1,5 +1,6 @@
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.helpers.entity import EntityCategory
+from homeassistant.const import STATE_ON
 
 from ..const import DOMAIN, BRAND
 
@@ -56,7 +57,23 @@ class Nhc2GenericEnergyhomeReportInstantUsageEntity(BinarySensorEntity):
     def on_change(self):
         # Re-enable reporting when it is turned off
         if self._device.is_report_instant_usage is False:
+            if self._is_report_instant_usage_re_enabling_disabled():
+                _LOGGER.debug(f'{self.name} re-enabling disabled')
+                return
+
             _LOGGER.debug(f'{self.name} re-enabled')
             self._device.enable_report_instant_usage(self._gateway)
 
         self.schedule_update_ha_state()
+
+    def _is_report_instant_usage_re_enabling_disabled(self) -> bool:
+        disable_report_instant_usage_re_enabling_entity = self.hass.states.get(
+            self.entity_id.replace('binary_sensor.', 'switch.').replace('_report_instant_usage',
+                                                                        '_disable_report_instant_usage_re_enabling')
+        )
+
+        if disable_report_instant_usage_re_enabling_entity is None:
+            _LOGGER.debug(f'{self.name} no Disable Report Instant Usage Re-enabling entity found.')
+            return False
+
+        return disable_report_instant_usage_re_enabling_entity.state == STATE_ON

--- a/custom_components/nhc2/entities/generic_smartplug_disable_report_instant_usage_re_enabling.py
+++ b/custom_components/nhc2/entities/generic_smartplug_disable_report_instant_usage_re_enabling.py
@@ -1,0 +1,87 @@
+from homeassistant.components.input_boolean import RestoreEntity
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.const import STATE_OFF, STATE_ON
+
+from ..const import DOMAIN, BRAND
+
+from ..nhccoco.devices.generic_smartplug import CocoGenericSmartplug
+
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Nhc2GenericSmartplugDisableReportInstantUsageReEnablingEntity(RestoreEntity):
+    _attr_has_entity_name = True
+
+    def __init__(self, device_instance: CocoGenericSmartplug, hub, gateway):
+        """Initialize an input boolean."""
+        self._device = device_instance
+        self._hub = hub
+        self._gateway = gateway
+
+        self._device.after_change_callbacks.append(self.on_change)
+
+        self._attr_available = self._device.is_online
+        self._attr_unique_id = device_instance.uuid + '_disable_report_instant_usage_re_enabling'
+        self._attr_should_poll = False
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._attr_device_class = None
+
+        self._state = None
+
+    @property
+    def name(self) -> str:
+        return 'Disable Report Instant Usage Re-enabling'
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        return {
+            'identifiers': {
+                (DOMAIN, self._device.uuid)
+            },
+            'name': self._device.name,
+            'manufacturer': BRAND,
+            'model': str.title(f'{self._device.model} ({self._device.type})'),
+            'via_device': self._hub
+        }
+
+    @property
+    def state(self):
+        if self._state is None:
+            return STATE_OFF
+
+        return self._state
+
+    @property
+    def is_on(self) -> bool:
+        return self._state == STATE_ON
+
+    def on_change(self):
+        pass
+
+    def _start_reporting_if_enabled(self):
+        if not self.is_on:
+            self._device.enable_report_instant_usage(self._gateway)
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        state = await self.async_get_last_state()
+        if not state:
+            # Fallback, if no previous state is found, assume it is off
+            self._state = STATE_OFF
+        else:
+            self._state = state.state
+
+        self.async_schedule_update_ha_state(True)
+        self._start_reporting_if_enabled()
+
+    async def async_turn_on(self, **kwargs):
+        self._state = STATE_ON
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs):
+        self._state = STATE_OFF
+        self._start_reporting_if_enabled()
+        self.async_write_ha_state()

--- a/custom_components/nhc2/entities/generic_smartplug_report_instant_usage.py
+++ b/custom_components/nhc2/entities/generic_smartplug_report_instant_usage.py
@@ -1,5 +1,6 @@
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.helpers.entity import EntityCategory
+from homeassistant.const import STATE_ON
 
 from ..const import DOMAIN, BRAND
 
@@ -29,9 +30,6 @@ class Nhc2GenericSmartplugReportInstantUsageEntity(BinarySensorEntity):
         self._attr_state_class = None
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
-        # Start reporting
-        self._device.enable_report_instant_usage(self._gateway)
-
     @property
     def name(self) -> str:
         return 'Report Instant Usage'
@@ -56,7 +54,23 @@ class Nhc2GenericSmartplugReportInstantUsageEntity(BinarySensorEntity):
     def on_change(self):
         # Re-enable reporting when it is turned off
         if self._device.is_report_instant_usage is False:
+            if self._is_report_instant_usage_re_enabling_disabled():
+                _LOGGER.debug(f'{self.name} re-enabling disabled')
+                return
+
             _LOGGER.debug(f'{self.name} re-enabled')
             self._device.enable_report_instant_usage(self._gateway)
 
         self.schedule_update_ha_state()
+
+    def _is_report_instant_usage_re_enabling_disabled(self) -> bool:
+        disable_report_instant_usage_re_enabling_entity = self.hass.states.get(
+            self.entity_id.replace('binary_sensor.', 'switch.').replace('_report_instant_usage',
+                                                                        '_disable_report_instant_usage_re_enabling')
+        )
+
+        if disable_report_instant_usage_re_enabling_entity is None:
+            _LOGGER.debug(f'{self.name} no Disable Report Instant Usage Re-enabling entity found.')
+            return False
+
+        return disable_report_instant_usage_re_enabling_entity.state == STATE_ON

--- a/custom_components/nhc2/entities/naso_smartplug_disable_report_instant_usage_re_enabling.py
+++ b/custom_components/nhc2/entities/naso_smartplug_disable_report_instant_usage_re_enabling.py
@@ -1,0 +1,88 @@
+from homeassistant.components.input_boolean import RestoreEntity
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.const import STATE_OFF, STATE_ON
+
+from ..const import DOMAIN, BRAND
+
+from ..nhccoco.devices.naso_smartplug import CocoNasoSmartplug
+
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Nhc2NasoSmartplugDisableReportInstantUsageReEnablingEntity(RestoreEntity):
+    _attr_has_entity_name = True
+
+    def __init__(self, device_instance: CocoNasoSmartplug, hub, gateway):
+        """Initialize an input boolean."""
+        self._device = device_instance
+        self._hub = hub
+        self._gateway = gateway
+
+        self._device.after_change_callbacks.append(self.on_change)
+
+        self._attr_available = self._device.is_online
+        self._attr_unique_id = device_instance.uuid + '_disable_report_instant_usage_re_enabling'
+        self._attr_should_poll = False
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._attr_device_class = None
+
+        self._state = None
+
+    @property
+    def name(self) -> str:
+        return 'Disable Report Instant Usage Re-enabling'
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        return {
+            'identifiers': {
+                (DOMAIN, self._device.uuid)
+            },
+            'name': self._device.name,
+            'manufacturer': BRAND,
+            'model': str.title(f'{self._device.model} ({self._device.type})'),
+            'via_device': self._hub
+        }
+
+    @property
+    def state(self):
+        if self._state is None:
+            return STATE_OFF
+
+        return self._state
+
+    @property
+    def is_on(self) -> bool:
+        return self._state == STATE_ON
+
+    def on_change(self):
+        pass
+
+    def _start_reporting_if_enabled(self):
+        if not self.is_on:
+            self._device.enable_report_instant_usage(self._gateway)
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        state = await self.async_get_last_state()
+
+        if not state:
+            # Fallback, if no previous state is found, assume it is off
+            self._state = STATE_OFF
+        else:
+            self._state = state.state
+
+        self.async_schedule_update_ha_state(True)
+        self._start_reporting_if_enabled()
+
+    async def async_turn_on(self, **kwargs):
+        self._state = STATE_ON
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs):
+        self._state = STATE_OFF
+        self._start_reporting_if_enabled()
+        self.async_write_ha_state()

--- a/custom_components/nhc2/entities/naso_smartplug_report_instant_usage.py
+++ b/custom_components/nhc2/entities/naso_smartplug_report_instant_usage.py
@@ -1,5 +1,6 @@
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.helpers.entity import EntityCategory
+from homeassistant.const import STATE_ON
 
 from ..const import DOMAIN, BRAND
 
@@ -29,9 +30,6 @@ class Nhc2NasoSmartplugReportInstantUsageEntity(BinarySensorEntity):
         self._attr_state_class = None
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
-        # Start reporting
-        self._device.enable_report_instant_usage(self._gateway)
-
     @property
     def name(self) -> str:
         return 'Report Instant Usage'
@@ -56,7 +54,23 @@ class Nhc2NasoSmartplugReportInstantUsageEntity(BinarySensorEntity):
     def on_change(self):
         # Re-enable reporting when it is turned off
         if self._device.is_report_instant_usage is False:
+            if self._is_report_instant_usage_re_enabling_disabled():
+                _LOGGER.debug(f'{self.name} re-enabling disabled')
+                return
+
             _LOGGER.debug(f'{self.name} re-enabled')
             self._device.enable_report_instant_usage(self._gateway)
 
         self.schedule_update_ha_state()
+
+    def _is_report_instant_usage_re_enabling_disabled(self) -> bool:
+        disable_report_instant_usage_re_enabling_entity = self.hass.states.get(
+            self.entity_id.replace('binary_sensor.', 'switch.').replace('_report_instant_usage',
+                                                                        '_disable_report_instant_usage_re_enabling')
+        )
+
+        if disable_report_instant_usage_re_enabling_entity is None:
+            _LOGGER.debug(f'{self.name} no Disable Report Instant Usage Re-enabling entity found.')
+            return False
+
+        return disable_report_instant_usage_re_enabling_entity.state == STATE_ON

--- a/custom_components/nhc2/switch.py
+++ b/custom_components/nhc2/switch.py
@@ -9,16 +9,22 @@ from .entities.accesscontrol_action_basicstate_switch import Nhc2AccesscontrolAc
 from .entities.bellbutton_action_basicstate_switch import Nhc2BellbuttonActionBasicStateSwitchEntity
 from .entities.condition_action_switch import Nhc2ConditionActionSwitchEntity
 from .entities.flag_action_switch import Nhc2FlagActionSwitchEntity
+from .entities.electricity_clamp_centralmeter_disable_report_instant_usage_re_enabling import \
+    Nhc2ElectricityClampCentralmeterDisableReportInstantUsageReEnablingEntity
 from .entities.generic_action_basicstate import Nhc2GenericActionBasicStateEntity
 from .entities.generic_domestichotwaterunit_boost import Nhc2GenericDomestichotwaterunitBoostEntity
 from .entities.generic_energyhome_disable_report_instant_usage_re_enabling import \
     Nhc2GenericEnergyhomeDisableReportInstantUsageReEnablingEntity
 from .entities.generic_fan_boost import Nhc2GenericFanBoostEntity
 from .entities.generic_hvac_overrule_active import Nhc2GenericHvacOverruleActiveEntity
+from .entities.generic_smartplug_disable_report_instant_usage_re_enabling import \
+    Nhc2GenericSmartplugDisableReportInstantUsageReEnablingEntity
 from .entities.hvacthermostat_hvac_ecosave import Nhc2HvacthermostatHvacEcoSaveEntity
 from .entities.hvacthermostat_hvac_thermostat_on import Nhc2HvacthermostatHvacThermostatOnEntity
 from .entities.hvacthermostat_hvac_overrule_active import Nhc2HvacthermostatHvacOverruleActiveEntity
 from .entities.hvacthermostat_hvac_protect_mode import Nhc2HvacthermostatHvacProtectModeEntity
+from .entities.naso_smartplug_disable_report_instant_usage_re_enabling import \
+    Nhc2NasoSmartplugDisableReportInstantUsageReEnablingEntity
 from .entities.overallcomfort_action_basicstate import Nhc2OverallcomfortActionBasicStateEntity
 from .entities.pir_action_basicstate import Nhc2PirActionBasicStateEntity
 from .entities.relay_action_switch import Nhc2RelayActionSwitchEntity
@@ -31,12 +37,15 @@ from .nhccoco.devices.accesscontrol_action import CocoAccesscontrolAction
 from .nhccoco.devices.bellbutton_action import CocoBellbuttonAction
 from .nhccoco.devices.condition_action import CocoConditionAction
 from .nhccoco.devices.flag_action import CocoFlagAction
+from .nhccoco.devices.electricity_clamp_centralmeter import CocoElectricityClampCentralmeter
 from .nhccoco.devices.generic_action import CocoGenericAction
 from .nhccoco.devices.generic_domestichotwaterunit import CocoGenericDomestichotwaterunit
 from .nhccoco.devices.generic_energyhome import CocoGenericEnergyhome
 from .nhccoco.devices.generic_fan import CocoGenericFan
 from .nhccoco.devices.generic_hvac import CocoGenericHvac
+from .nhccoco.devices.generic_smartplug import CocoGenericSmartplug
 from .nhccoco.devices.hvacthermostat_hvac import CocoHvacthermostatHvac
+from .nhccoco.devices.naso_smartplug import CocoNasoSmartplug
 from .nhccoco.devices.overallcomfort_action import CocoOverallcomfortAction
 from .nhccoco.devices.pir_action import CocoPirAction
 from .nhccoco.devices.simulation_action import CocoSimulationAction
@@ -167,6 +176,39 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         entities = []
         for device_instance in device_instances:
             entities.append(Nhc2RelayActionSwitchEntity(device_instance, hub, gateway))
+
+        async_add_entities(entities)
+
+    device_instances = gateway.get_device_instances(CocoNasoSmartplug)
+    _LOGGER.info('→ Found %s NHC Zigbee Smart plugs', len(device_instances))
+    if len(device_instances) > 0:
+        entities = []
+        for device_instance in device_instances:
+            entities.append(Nhc2NasoSmartplugDisableReportInstantUsageReEnablingEntity(device_instance, hub, gateway))
+
+        async_add_entities(entities)
+
+    device_instances = gateway.get_device_instances(CocoGenericSmartplug)
+    _LOGGER.info('→ Found %s Generic Zigbee Smart plugs', len(device_instances))
+    if len(device_instances) > 0:
+        entities = []
+        for device_instance in device_instances:
+            entities.append(
+                Nhc2GenericSmartplugDisableReportInstantUsageReEnablingEntity(device_instance, hub, gateway)
+            )
+
+        async_add_entities(entities)
+
+    device_instances = gateway.get_device_instances(CocoElectricityClampCentralmeter)
+    _LOGGER.info('→ Found %s Electricity Metering modules', len(device_instances))
+    if len(device_instances) > 0:
+        entities = []
+        for device_instance in device_instances:
+            entities.append(
+                Nhc2ElectricityClampCentralmeterDisableReportInstantUsageReEnablingEntity(
+                    device_instance, hub, gateway
+                )
+            )
 
         async_add_entities(entities)
 

--- a/custom_components/nhc2/switch.py
+++ b/custom_components/nhc2/switch.py
@@ -11,6 +11,8 @@ from .entities.condition_action_switch import Nhc2ConditionActionSwitchEntity
 from .entities.flag_action_switch import Nhc2FlagActionSwitchEntity
 from .entities.generic_action_basicstate import Nhc2GenericActionBasicStateEntity
 from .entities.generic_domestichotwaterunit_boost import Nhc2GenericDomestichotwaterunitBoostEntity
+from .entities.generic_energyhome_disable_report_instant_usage_re_enabling import \
+    Nhc2GenericEnergyhomeDisableReportInstantUsageReEnablingEntity
 from .entities.generic_fan_boost import Nhc2GenericFanBoostEntity
 from .entities.generic_hvac_overrule_active import Nhc2GenericHvacOverruleActiveEntity
 from .entities.hvacthermostat_hvac_ecosave import Nhc2HvacthermostatHvacEcoSaveEntity
@@ -31,6 +33,7 @@ from .nhccoco.devices.condition_action import CocoConditionAction
 from .nhccoco.devices.flag_action import CocoFlagAction
 from .nhccoco.devices.generic_action import CocoGenericAction
 from .nhccoco.devices.generic_domestichotwaterunit import CocoGenericDomestichotwaterunit
+from .nhccoco.devices.generic_energyhome import CocoGenericEnergyhome
 from .nhccoco.devices.generic_fan import CocoGenericFan
 from .nhccoco.devices.generic_hvac import CocoGenericHvac
 from .nhccoco.devices.hvacthermostat_hvac import CocoHvacthermostatHvac
@@ -164,6 +167,17 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         entities = []
         for device_instance in device_instances:
             entities.append(Nhc2RelayActionSwitchEntity(device_instance, hub, gateway))
+
+        async_add_entities(entities)
+
+    device_instances = gateway.get_device_instances(CocoGenericEnergyhome)
+    _LOGGER.info('→ Found %s Energy Home\'s', len(device_instances))
+    if len(device_instances) > 0:
+        entities = []
+        for device_instance in device_instances:
+            entities.append(
+                Nhc2GenericEnergyhomeDisableReportInstantUsageReEnablingEntity(device_instance, hub, gateway)
+            )
 
         async_add_entities(entities)
 


### PR DESCRIPTION
**Do not merge: still work in progress**

Introduce a toggle for devices with Report Instant Usage to disable the automatic re-enabling of the Report Instant Usage property.

This allows users to switch of the Energy reporting for certain devices.

### Fixes
* https://github.com/joleys/niko-home-control-II/issues/68