### PR TITLE
Unable to parse services.yaml

### DIFF
--- a/custom_components/nhc2/services.yaml
+++ b/custom_components/nhc2/services.yaml
@@ -5,7 +5,6 @@ set_light_brightness:
   target:
     entity:
       domain: light
-      multiple: true
   fields:
     light_brightness:
       name: Brightness


### PR DESCRIPTION
Since version 2023.4.x I got a warning: `Unable to parse services.yaml`

Be careful, as this potentially a breaking change. So this should be mentioned in the changelog. And it probably should be a major release?

It seems like `multiple` is not supported anymore. But I don't found any documentation on this matter.



