### PR TITLE
Minor bugfixes

### DIFF
--- a/custom_components/nhc2/entities/robinsip_videodoorstation_camera.py
+++ b/custom_components/nhc2/entities/robinsip_videodoorstation_camera.py
@@ -73,6 +73,10 @@ class Nhc2RobinsipVideodoorstationCameraEntity(MjpegCamera):
 
             p = ImageFile.Parser()
             p.feed(image)
+
+            if p.image is None:
+                continue
+
             _LOGGER.debug(f'Image size for still image is: {p.image.size}')
 
             if p.image is None:

--- a/custom_components/nhc2/nhccoco/devices/controller.py
+++ b/custom_components/nhc2/nhccoco/devices/controller.py
@@ -34,3 +34,6 @@ class CocoController:
         if self._after_change_callbacks:
             for callback in self._after_change_callbacks:
                 callback()
+
+    def set_disconnected(self):
+        return


### PR DESCRIPTION
**Ignore invalid images**
If an invalid image is returned it won't have the size properties. This was
triggering errors (in the logs).

**Implement missing set_disconnected method**
Because the CocoController does not extend CoCoDevice it was missing the
set_disconnected method