### PR TITLE
Call the press (trigger) method only after checking the current state.

### DIFF
--- a/custom_components/nhc2/entities/accesscontrol_action_basicstate_switch.py
+++ b/custom_components/nhc2/entities/accesscontrol_action_basicstate_switch.py
@@ -42,9 +42,11 @@ class Nhc2AccesscontrolActionBasicStateSwitchEntity(SwitchEntity):
         self.schedule_update_ha_state()
 
     async def async_turn_on(self):
-        self._device.press(self._gateway)
+        if not self.is_on:
+            self._device.press(self._gateway)
         self.on_change()
 
     async def async_turn_off(self):
-        self._device.press(self._gateway)
+        if self.is_on:
+            self._device.press(self._gateway)
         self.on_change()

--- a/custom_components/nhc2/entities/bellbutton_action_basicstate_switch.py
+++ b/custom_components/nhc2/entities/bellbutton_action_basicstate_switch.py
@@ -42,9 +42,11 @@ class Nhc2BellbuttonActionBasicStateSwitchEntity(SwitchEntity):
         self.schedule_update_ha_state()
 
     async def async_turn_on(self):
-        self._device.press(self._gateway)
+        if not self.is_on:
+            self._device.press(self._gateway)
         self.on_change()
 
     async def async_turn_off(self):
-        self._device.press(self._gateway)
+        if self.is_on:
+            self._device.press(self._gateway)
         self.on_change()

--- a/custom_components/nhc2/entities/condition_action_switch.py
+++ b/custom_components/nhc2/entities/condition_action_switch.py
@@ -42,9 +42,11 @@ class Nhc2ConditionActionSwitchEntity(SwitchEntity):
         self.schedule_update_ha_state()
 
     async def async_turn_on(self):
-        self._device.press(self._gateway)
+        if not self.is_on:
+            self._device.press(self._gateway)
         self.on_change()
 
     async def async_turn_off(self):
-        self._device.press(self._gateway)
+        if self.is_on:
+            self._device.press(self._gateway)
         self.on_change()

--- a/custom_components/nhc2/entities/generic_action_basicstate.py
+++ b/custom_components/nhc2/entities/generic_action_basicstate.py
@@ -42,9 +42,11 @@ class Nhc2GenericActionBasicStateEntity(SwitchEntity):
         self.schedule_update_ha_state()
 
     async def async_turn_on(self):
-        self._device.press(self._gateway)
+        if not self.is_on:
+            self._device.press(self._gateway)
         self.on_change()
 
     async def async_turn_off(self):
-        self._device.press(self._gateway)
+        if self.is_on:
+            self._device.press(self._gateway)
         self.on_change()

--- a/custom_components/nhc2/entities/overallcomfort_action_basicstate.py
+++ b/custom_components/nhc2/entities/overallcomfort_action_basicstate.py
@@ -42,9 +42,11 @@ class Nhc2OverallcomfortActionBasicStateEntity(SwitchEntity):
         self.schedule_update_ha_state()
 
     async def async_turn_on(self):
-        self._device.press(self._gateway)
+        if not self.is_on:
+            self._device.press(self._gateway)
         self.on_change()
 
     async def async_turn_off(self):
-        self._device.press(self._gateway)
+        if self.is_on:
+            self._device.press(self._gateway)
         self.on_change()

--- a/custom_components/nhc2/entities/pir_action_basicstate.py
+++ b/custom_components/nhc2/entities/pir_action_basicstate.py
@@ -42,9 +42,11 @@ class Nhc2PirActionBasicStateEntity(SwitchEntity):
         self.schedule_update_ha_state()
 
     async def async_turn_on(self):
-        self._device.press(self._gateway)
+        if not self.is_on:
+            self._device.press(self._gateway)
         self.on_change()
 
     async def async_turn_off(self):
-        self._device.press(self._gateway)
+        if self.is_on:
+            self._device.press(self._gateway)
         self.on_change()

--- a/custom_components/nhc2/entities/simulation_action_basicstate_switch.py
+++ b/custom_components/nhc2/entities/simulation_action_basicstate_switch.py
@@ -42,9 +42,11 @@ class Nhc2SimulationActionBasicStateSwitchEntity(SwitchEntity):
         self.schedule_update_ha_state()
 
     async def async_turn_on(self):
-        self._device.press(self._gateway)
+        if not self.is_on:
+            self._device.press(self._gateway)
         self.on_change()
 
     async def async_turn_off(self):
-        self._device.press(self._gateway)
+        if self.is_on:
+            self._device.press(self._gateway)
         self.on_change()


### PR DESCRIPTION
The press method was always called, which results in weird behaviour, for instance when calling a the turn_off service when the switch is already off. In that case the switch would be turned on instead of turning off.

This was reported in https://github.com/joleys/niko-home-control-II/issues/73