### PR TITLE
Check if supported features should include Preset Mode

### DIFF
--- a/custom_components/nhc2/entities/generic_hvac_climate.py
+++ b/custom_components/nhc2/entities/generic_hvac_climate.py
@@ -65,10 +65,16 @@ class Nhc2GenericHvacClimateEntity(ClimateEntity):
 
     @property
     def supported_features(self) -> int:
-        if self._device.supports_fan_speed:
+        if self._device.supports_fan_speed and self._device.supports_program:
             return ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.PRESET_MODE
 
-        return ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
+        if self._device.supports_fan_speed:
+            return ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
+
+        if self._device.supports_program:
+            return ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
+
+        return ClimateEntityFeature.TARGET_TEMPERATURE
 
     @property
     def hvac_action(self):

--- a/custom_components/nhc2/nhccoco/devices/generic_hvac.py
+++ b/custom_components/nhc2/nhccoco/devices/generic_hvac.py
@@ -32,6 +32,10 @@ class CocoGenericHvac(CoCoDevice):
         return self.extract_property_definition_description_choices(PROPERTY_PROGRAM)
 
     @property
+    def supports_program(self) -> bool:
+        return self.has_property(PROPERTY_PROGRAM)
+
+    @property
     def operation_mode(self) -> str:
         return self.extract_property_value(PROPERTY_OPERATION_MODE)
 


### PR DESCRIPTION
If the programs property is not available the climate entity should not have the possibility to use presets.

This should resolve https://github.com/joleys/niko-home-control-II/issues/80