### PR TITLE
Support for electricalheating action

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,16 @@ __Remark:__ This device is not documented/supported by Niko.
 * **Cooling Mode Binary Sensor**
 * **Heating Mode Binary Sensor**
 
+### Electrical Heating Action (untested)
+
+__Remark:__ This device is not documented/supported by Niko.
+
+This action is exposed as a button.
+
+#### Entities
+
+* **Basic State Binary Sensor**, the current status of the action.
+
 ## Not yet supported
 
 * Sonos Speaker

--- a/custom_components/nhc2/binary_sensor.py
+++ b/custom_components/nhc2/binary_sensor.py
@@ -18,6 +18,7 @@ from .entities.bellbutton_action_decline_call_applied_on_all_devices import \
 from .entities.comfort_action_basicstate import Nhc2ComfortActionBasicStateEntity
 from .entities.comfort_action_mood_active import Nhc2ComfortActionMoodActiveEntity
 from .entities.dimmer_action_aligned import Nhc2DimmerActionAlignedEntity
+from .entities.electricalheating_action_basicstate import Nhc2ElectricalheatingActionBasicStateEntity
 from .entities.electricity_clamp_centralmeter_report_instant_usage import \
     Nhc2ElectricityClampCentralmeterReportInstantUsageEntity
 from .entities.garagedoor_action_port_closed import Nhc2GaragedoorActionPortClosedEntity
@@ -42,6 +43,7 @@ from .nhccoco.devices.audiocontrol_action import CocoAudiocontrolAction
 from .nhccoco.devices.bellbutton_action import CocoBellbuttonAction
 from .nhccoco.devices.comfort_action import CocoComfortAction
 from .nhccoco.devices.dimmer_action import CocoDimmerAction
+from .nhccoco.devices.electricalheating_action import CocoElectricalheatingAction
 from .nhccoco.devices.electricity_clamp_centralmeter import CocoElectricityClampCentralmeter
 from .nhccoco.devices.garagedoor_action import CocoGaragedoorAction
 from .nhccoco.devices.gate_action import CocoGateAction
@@ -241,5 +243,14 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         for device_instance in device_instances:
             entities.append(Nhc2HeatingcoolingActionCoolingModeEntity(device_instance, hub, gateway))
             entities.append(Nhc2HeatingcoolingActionHeatingModeEntity(device_instance, hub, gateway))
+
+        async_add_entities(entities)
+
+    device_instances = gateway.get_device_instances(CocoElectricalheatingAction)
+    _LOGGER.info('→ Found %s Electricalheating Actions (undocumented)', len(device_instances))
+    if len(device_instances) > 0:
+        entities = []
+        for device_instance in device_instances:
+            entities.append(Nhc2ElectricalheatingActionBasicStateEntity(device_instance, hub, gateway))
 
         async_add_entities(entities)

--- a/custom_components/nhc2/button.py
+++ b/custom_components/nhc2/button.py
@@ -7,8 +7,10 @@ from .nhccoco.coco import CoCo
 
 from .entities.alloff_action_button import Nhc2AlloffActionButtonEntity
 from .entities.comfort_action_button import Nhc2ComfortActionButtonEntity
+from .entities.electricalheating_action_button import Nhc2ElectricalHeatingActionButtonEntity
 from .nhccoco.devices.alloff_action import CocoAlloffAction
 from .nhccoco.devices.comfort_action import CocoComfortAction
+from .nhccoco.devices.electricalheating_action import CocoElectricalheatingAction
 
 from .const import DOMAIN, KEY_GATEWAY
 
@@ -40,5 +42,14 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         entities = []
         for device_instance in device_instances:
             entities.append(Nhc2ComfortActionButtonEntity(device_instance, hub, gateway))
+
+        async_add_entities(entities)
+
+    device_instances = gateway.get_device_instances(CocoElectricalheatingAction)
+    _LOGGER.info('→ Found %s Electricalheating Actions (undocumented)', len(device_instances))
+    if len(device_instances) > 0:
+        entities = []
+        for device_instance in device_instances:
+            entities.append(Nhc2ElectricalHeatingActionButtonEntity(device_instance, hub, gateway))
 
         async_add_entities(entities)

--- a/custom_components/nhc2/entities/electricalheating_action_basicstate.py
+++ b/custom_components/nhc2/entities/electricalheating_action_basicstate.py
@@ -1,0 +1,48 @@
+from homeassistant.components.binary_sensor import BinarySensorEntity
+
+from ..const import DOMAIN, BRAND
+
+from ..nhccoco.devices.electricalheating_action import CocoElectricalheatingAction
+
+
+class Nhc2ElectricalheatingActionBasicStateEntity(BinarySensorEntity):
+    _attr_has_entity_name = True
+
+    def __init__(self, device_instance: CocoElectricalheatingAction, hub, gateway):
+        """Initialize a binary sensor."""
+        self._device = device_instance
+        self._hub = hub
+        self._gateway = gateway
+
+        self._device.after_change_callbacks.append(self.on_change)
+
+        self._attr_available = self._device.is_online
+        self._attr_unique_id = device_instance.uuid + '_basic_state'
+        self._attr_should_poll = False
+
+        self._attr_state = self._device.is_basic_state_on
+        self._attr_state_class = None
+
+    @property
+    def name(self) -> str:
+        return 'Basic State'
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        return {
+            'identifiers': {
+                (DOMAIN, self._device.uuid)
+            },
+            'name': self._device.name,
+            'manufacturer': BRAND,
+            'model': str.title(f'{self._device.model} ({self._device.type})'),
+            'via_device': self._hub
+        }
+
+    @property
+    def is_on(self) -> bool:
+        return self._device.is_basic_state_on
+
+    def on_change(self):
+        self.schedule_update_ha_state()

--- a/custom_components/nhc2/entities/electricalheating_action_button.py
+++ b/custom_components/nhc2/entities/electricalheating_action_button.py
@@ -1,0 +1,46 @@
+from homeassistant.components.button import ButtonEntity
+
+from ..const import DOMAIN, BRAND
+
+from ..nhccoco.devices.electricalheating_action import CocoElectricalheatingAction
+
+
+class Nhc2ElectricalHeatingActionButtonEntity(ButtonEntity):
+    _attr_has_entity_name = True
+    _attr_name = None
+
+    def __init__(self, device_instance: CocoElectricalheatingAction, hub, gateway):
+        """Initialize a button."""
+        self._device = device_instance
+        self._hub = hub
+        self._gateway = gateway
+
+        self._device.after_change_callbacks.append(self.on_change)
+
+        self._attr_available = self._device.is_online
+        self._attr_unique_id = device_instance.uuid
+        self._attr_should_poll = False
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        return {
+            'identifiers': {
+                (DOMAIN, self._device.uuid)
+            },
+            'name': self._device.name,
+            'manufacturer': BRAND,
+            'model': str.title(f'{self._device.model} ({self._device.type})'),
+            'via_device': self._hub
+        }
+
+    @property
+    def is_on(self) -> bool:
+        return self._device.is_basic_state_on
+
+    def on_change(self):
+        self.schedule_update_ha_state()
+
+    async def async_press(self) -> None:
+        self._device.press(self._gateway)
+        self.on_change()

--- a/custom_components/nhc2/entities/generic_hvac_climate.py
+++ b/custom_components/nhc2/entities/generic_hvac_climate.py
@@ -65,10 +65,16 @@ class Nhc2GenericHvacClimateEntity(ClimateEntity):
 
     @property
     def supported_features(self) -> int:
-        if self._device.supports_fan_speed:
+        if self._device.supports_fan_speed and self._device.supports_program:
             return ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.PRESET_MODE
 
-        return ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
+        if self._device.supports_fan_speed:
+            return ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
+
+        if self._device.supports_program:
+            return ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
+
+        return ClimateEntityFeature.TARGET_TEMPERATURE
 
     @property
     def hvac_action(self):

--- a/custom_components/nhc2/nhccoco/coco.py
+++ b/custom_components/nhc2/nhccoco/coco.py
@@ -16,6 +16,7 @@ from .devices.comfort_action import CocoComfortAction
 from .devices.condition_action import CocoConditionAction
 from .devices.controller import CocoController
 from .devices.dimmer_action import CocoDimmerAction
+from .devices.electricalheating_action import CocoElectricalheatingAction
 from .devices.electricity_clamp_centralmeter import CocoElectricityClampCentralmeter
 from .devices.fan_action import CocoFanAction
 from .devices.flag_action import CocoFlagAction

--- a/custom_components/nhc2/nhccoco/devices/electricalheating_action.py
+++ b/custom_components/nhc2/nhccoco/devices/electricalheating_action.py
@@ -1,0 +1,34 @@
+from ..const import DEVICE_DESCRIPTOR_PROPERTIES, PROPERTY_BASIC_STATE, PROPERTY_BASIC_STATE_VALUE_ON, \
+    PROPERTY_BASIC_STATE_VALUE_TRIGGERED
+
+from .device import CoCoDevice
+
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CocoElectricalheatingAction(CoCoDevice):
+    @property
+    def basic_state(self) -> str:
+        return self.extract_property_value(PROPERTY_BASIC_STATE)
+
+    @property
+    def is_basic_state_on(self) -> bool:
+        return self.basic_state == PROPERTY_BASIC_STATE_VALUE_ON
+
+    def on_change(self, topic: str, payload: dict):
+        _LOGGER.debug(f'{self.name} changed. Topic: {topic} | Data: {payload}')
+        if DEVICE_DESCRIPTOR_PROPERTIES in payload:
+            self.merge_properties(payload[DEVICE_DESCRIPTOR_PROPERTIES])
+
+        if self._after_change_callbacks:
+            for callback in self._after_change_callbacks:
+                callback()
+
+    def press(self, gateway):
+        gateway.add_device_control(
+            self.uuid,
+            PROPERTY_BASIC_STATE,
+            PROPERTY_BASIC_STATE_VALUE_TRIGGERED
+        )

--- a/custom_components/nhc2/nhccoco/devices/generic_hvac.py
+++ b/custom_components/nhc2/nhccoco/devices/generic_hvac.py
@@ -32,6 +32,10 @@ class CocoGenericHvac(CoCoDevice):
         return self.extract_property_definition_description_choices(PROPERTY_PROGRAM)
 
     @property
+    def supports_program(self) -> bool:
+        return self.has_property(PROPERTY_PROGRAM)
+
+    @property
     def operation_mode(self) -> str:
         return self.extract_property_value(PROPERTY_OPERATION_MODE)
 


### PR DESCRIPTION
@sgisgi3200 reported an error in https://github.com/joleys/niko-home-control-II/issues/80, which also shows an error related to an unknown device: Electricalheating Action

This PR adds support for this device. 

It is exposed as a button and a binary sensor which reflects the current state of that action.