### PR TITLE
Bugfix: Make changing Unit of Measurement through interface work.

### DIFF
--- a/custom_components/nhc2/entities/electricity_clamp_centralmeter_electrical_power.py
+++ b/custom_components/nhc2/entities/electricity_clamp_centralmeter_electrical_power.py
@@ -26,6 +26,7 @@ class Nhc2ElectricityClampCentralmeterElectricalPowerEntity(SensorEntity):
         self._attr_native_unit_of_measurement = UnitOfPower.WATT
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_suggested_display_precision = 3
+        self._attr_native_precision = 3
 
     @property
     def name(self) -> str:

--- a/custom_components/nhc2/entities/electricity_clamp_centralmeter_electrical_power.py
+++ b/custom_components/nhc2/entities/electricity_clamp_centralmeter_electrical_power.py
@@ -45,7 +45,7 @@ class Nhc2ElectricityClampCentralmeterElectricalPowerEntity(SensorEntity):
         }
 
     @property
-    def state(self) -> float:
+    def native_value(self) -> float:
         return self._device.electrical_power
 
     def on_change(self):

--- a/custom_components/nhc2/entities/electricity_clamp_centralmeter_electrical_power.py
+++ b/custom_components/nhc2/entities/electricity_clamp_centralmeter_electrical_power.py
@@ -25,7 +25,7 @@ class Nhc2ElectricityClampCentralmeterElectricalPowerEntity(SensorEntity):
         self._attr_native_value = self._device.electrical_power
         self._attr_native_unit_of_measurement = UnitOfPower.WATT
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_suggested_display_precision = 0
+        self._attr_suggested_display_precision = 3
 
     @property
     def name(self) -> str:

--- a/custom_components/nhc2/entities/electricity_clamp_centralmeter_electrical_power_consumption.py
+++ b/custom_components/nhc2/entities/electricity_clamp_centralmeter_electrical_power_consumption.py
@@ -25,7 +25,7 @@ class Nhc2ElectricityClampCentralmeterElectricalPowerConsumptionEntity(SensorEnt
         self._attr_native_value = self._device.electrical_power
         self._attr_native_unit_of_measurement = UnitOfPower.WATT
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_suggested_display_precision = 0
+        self._attr_suggested_display_precision = 3
 
     @property
     def name(self) -> str:

--- a/custom_components/nhc2/entities/electricity_clamp_centralmeter_electrical_power_consumption.py
+++ b/custom_components/nhc2/entities/electricity_clamp_centralmeter_electrical_power_consumption.py
@@ -45,7 +45,7 @@ class Nhc2ElectricityClampCentralmeterElectricalPowerConsumptionEntity(SensorEnt
         }
 
     @property
-    def state(self) -> float:
+    def native_value(self) -> float:
         if self._device.electrical_power > 0:
             return self._device.electrical_power
 

--- a/custom_components/nhc2/entities/electricity_clamp_centralmeter_electrical_power_consumption.py
+++ b/custom_components/nhc2/entities/electricity_clamp_centralmeter_electrical_power_consumption.py
@@ -26,6 +26,7 @@ class Nhc2ElectricityClampCentralmeterElectricalPowerConsumptionEntity(SensorEnt
         self._attr_native_unit_of_measurement = UnitOfPower.WATT
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_suggested_display_precision = 3
+        self._attr_native_precision = 3
 
     @property
     def name(self) -> str:

--- a/custom_components/nhc2/entities/electricity_clamp_centralmeter_electrical_power_production.py
+++ b/custom_components/nhc2/entities/electricity_clamp_centralmeter_electrical_power_production.py
@@ -45,7 +45,7 @@ class Nhc2ElectricityClampCentralmeterElectricalPowerProductionEntity(SensorEnti
         }
 
     @property
-    def state(self) -> float:
+    def native_value(self) -> float:
         if self._device.electrical_power < 0:
             return -self._device.electrical_power
 

--- a/custom_components/nhc2/entities/electricity_clamp_centralmeter_electrical_power_production.py
+++ b/custom_components/nhc2/entities/electricity_clamp_centralmeter_electrical_power_production.py
@@ -25,7 +25,7 @@ class Nhc2ElectricityClampCentralmeterElectricalPowerProductionEntity(SensorEnti
         self._attr_native_value = self._device.electrical_power
         self._attr_native_unit_of_measurement = UnitOfPower.WATT
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_suggested_display_precision = 0
+        self._attr_suggested_display_precision = 3
 
     @property
     def name(self) -> str:

--- a/custom_components/nhc2/entities/electricity_clamp_centralmeter_electrical_power_production.py
+++ b/custom_components/nhc2/entities/electricity_clamp_centralmeter_electrical_power_production.py
@@ -26,6 +26,7 @@ class Nhc2ElectricityClampCentralmeterElectricalPowerProductionEntity(SensorEnti
         self._attr_native_unit_of_measurement = UnitOfPower.WATT
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_suggested_display_precision = 3
+        self._attr_native_precision = 3
 
     @property
     def name(self) -> str:

--- a/custom_components/nhc2/entities/generic_energyhome_electrical_power_consumption.py
+++ b/custom_components/nhc2/entities/generic_energyhome_electrical_power_consumption.py
@@ -26,6 +26,7 @@ class Nhc2GenericEnergyhomeElectricalPowerConsumptionEntity(SensorEntity):
         self._attr_native_unit_of_measurement = UnitOfPower.WATT
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_suggested_display_precision = 3
+        self._attr_native_precision = 3
 
     @property
     def name(self) -> str:

--- a/custom_components/nhc2/entities/generic_energyhome_electrical_power_consumption.py
+++ b/custom_components/nhc2/entities/generic_energyhome_electrical_power_consumption.py
@@ -45,7 +45,7 @@ class Nhc2GenericEnergyhomeElectricalPowerConsumptionEntity(SensorEntity):
         }
 
     @property
-    def state(self) -> float:
+    def native_value(self) -> float:
         return self._device.electrical_power_consumption
 
     def on_change(self):

--- a/custom_components/nhc2/entities/generic_energyhome_electrical_power_from_grid.py
+++ b/custom_components/nhc2/entities/generic_energyhome_electrical_power_from_grid.py
@@ -26,6 +26,7 @@ class Nhc2GenericEnergyhomeElectricalPowerFromGridEntity(SensorEntity):
         self._attr_native_unit_of_measurement = UnitOfPower.WATT
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_suggested_display_precision = 3
+        self._attr_native_precision = 3
 
     @property
     def name(self) -> str:

--- a/custom_components/nhc2/entities/generic_energyhome_electrical_power_from_grid.py
+++ b/custom_components/nhc2/entities/generic_energyhome_electrical_power_from_grid.py
@@ -45,7 +45,7 @@ class Nhc2GenericEnergyhomeElectricalPowerFromGridEntity(SensorEntity):
         }
 
     @property
-    def state(self) -> float:
+    def native_value(self) -> float:
         return self._device.electrical_power_from_grid
 
     def on_change(self):

--- a/custom_components/nhc2/entities/generic_energyhome_electrical_power_production.py
+++ b/custom_components/nhc2/entities/generic_energyhome_electrical_power_production.py
@@ -26,6 +26,7 @@ class Nhc2GenericEnergyhomeElectricalPowerProductionEntity(SensorEntity):
         self._attr_native_unit_of_measurement = UnitOfPower.WATT
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_suggested_display_precision = 3
+        self._attr_native_precision = 3
 
     @property
     def name(self) -> str:

--- a/custom_components/nhc2/entities/generic_energyhome_electrical_power_production.py
+++ b/custom_components/nhc2/entities/generic_energyhome_electrical_power_production.py
@@ -45,7 +45,7 @@ class Nhc2GenericEnergyhomeElectricalPowerProductionEntity(SensorEntity):
         }
 
     @property
-    def state(self) -> float:
+    def native_value(self) -> float:
         return self._device.electrical_power_production
 
     def on_change(self):

--- a/custom_components/nhc2/entities/generic_energyhome_electrical_power_self_consumption.py
+++ b/custom_components/nhc2/entities/generic_energyhome_electrical_power_self_consumption.py
@@ -26,6 +26,7 @@ class Nhc2GenericEnergyhomeElectricalPowerSelfConsumptionEntity(SensorEntity):
         self._attr_native_unit_of_measurement = UnitOfPower.WATT
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_suggested_display_precision = 3
+        self._attr_native_precision = 3
 
     @property
     def name(self) -> str:

--- a/custom_components/nhc2/entities/generic_energyhome_electrical_power_self_consumption.py
+++ b/custom_components/nhc2/entities/generic_energyhome_electrical_power_self_consumption.py
@@ -45,7 +45,7 @@ class Nhc2GenericEnergyhomeElectricalPowerSelfConsumptionEntity(SensorEntity):
         }
 
     @property
-    def state(self) -> float:
+    def native_value(self) -> float:
         return self._device.electrical_power_self_consumption
 
     def on_change(self):

--- a/custom_components/nhc2/entities/generic_energyhome_electrical_power_to_grid.py
+++ b/custom_components/nhc2/entities/generic_energyhome_electrical_power_to_grid.py
@@ -26,6 +26,7 @@ class Nhc2GenericEnergyhomeElectricalPowerToGridEntity(SensorEntity):
         self._attr_native_unit_of_measurement = UnitOfPower.WATT
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_suggested_display_precision = 3
+        self._attr_native_precision = 3
 
     @property
     def name(self) -> str:

--- a/custom_components/nhc2/entities/generic_energyhome_electrical_power_to_grid.py
+++ b/custom_components/nhc2/entities/generic_energyhome_electrical_power_to_grid.py
@@ -45,7 +45,7 @@ class Nhc2GenericEnergyhomeElectricalPowerToGridEntity(SensorEntity):
         }
 
     @property
-    def state(self) -> float:
+    def native_value(self) -> float:
         return self._device.electrical_power_to_grid
 
     def on_change(self):

--- a/custom_components/nhc2/entities/generic_fan_co2.py
+++ b/custom_components/nhc2/entities/generic_fan_co2.py
@@ -26,6 +26,7 @@ class Nhc2GenericFanCo2Entity(SensorEntity):
         self._attr_native_unit_of_measurement = CONCENTRATION_PARTS_PER_MILLION
         self._attr_state_class = None
         self._attr_suggested_display_precision = 0
+        self._attr_native_precision = 0
 
     @property
     def name(self) -> str:

--- a/custom_components/nhc2/entities/generic_fan_co2.py
+++ b/custom_components/nhc2/entities/generic_fan_co2.py
@@ -45,7 +45,7 @@ class Nhc2GenericFanCo2Entity(SensorEntity):
         }
 
     @property
-    def state(self) -> int:
+    def native_value(self) -> int:
         return self._device.co2
 
     def on_change(self):

--- a/custom_components/nhc2/entities/generic_fan_humidity.py
+++ b/custom_components/nhc2/entities/generic_fan_humidity.py
@@ -26,6 +26,7 @@ class Nhc2GenericFanHumidityEntity(SensorEntity):
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_state_class = None
         self._attr_suggested_display_precision = 0
+        self._attr_native_precision = 0
 
     @property
     def name(self) -> str:

--- a/custom_components/nhc2/entities/generic_fan_humidity.py
+++ b/custom_components/nhc2/entities/generic_fan_humidity.py
@@ -45,7 +45,7 @@ class Nhc2GenericFanHumidityEntity(SensorEntity):
         }
 
     @property
-    def state(self) -> int:
+    def native_value(self) -> int:
         return self._device.humidity
 
     def on_change(self):

--- a/custom_components/nhc2/entities/generic_smartplug_electrical_power.py
+++ b/custom_components/nhc2/entities/generic_smartplug_electrical_power.py
@@ -25,7 +25,7 @@ class Nhc2GenericSmartplugElectricalPowerEntity(SensorEntity):
         self._attr_native_value = self._device.electrical_power
         self._attr_native_unit_of_measurement = UnitOfPower.WATT
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_suggested_display_precision = 0
+        self._attr_suggested_display_precision = 3
 
     @property
     def name(self) -> str:

--- a/custom_components/nhc2/entities/generic_smartplug_electrical_power.py
+++ b/custom_components/nhc2/entities/generic_smartplug_electrical_power.py
@@ -45,7 +45,7 @@ class Nhc2GenericSmartplugElectricalPowerEntity(SensorEntity):
         }
 
     @property
-    def state(self) -> float:
+    def native_value(self) -> float:
         return self._device.electrical_power
 
     def on_change(self):

--- a/custom_components/nhc2/entities/generic_smartplug_electrical_power.py
+++ b/custom_components/nhc2/entities/generic_smartplug_electrical_power.py
@@ -26,6 +26,7 @@ class Nhc2GenericSmartplugElectricalPowerEntity(SensorEntity):
         self._attr_native_unit_of_measurement = UnitOfPower.WATT
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_suggested_display_precision = 3
+        self._attr_native_precision = 3
 
     @property
     def name(self) -> str:

--- a/custom_components/nhc2/entities/hvacthermostat_hvac_overrule_setpoint.py
+++ b/custom_components/nhc2/entities/hvacthermostat_hvac_overrule_setpoint.py
@@ -26,6 +26,7 @@ class Nhc2HvacthermostatHvacOverruleSetpointEntity(SensorEntity):
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
         self._attr_state_class = None
         self._attr_suggested_display_precision = 1
+        self._attr_native_precision = 1
 
     @property
     def name(self) -> str:

--- a/custom_components/nhc2/entities/hvacthermostat_hvac_overrule_setpoint.py
+++ b/custom_components/nhc2/entities/hvacthermostat_hvac_overrule_setpoint.py
@@ -45,7 +45,7 @@ class Nhc2HvacthermostatHvacOverruleSetpointEntity(SensorEntity):
         }
 
     @property
-    def state(self) -> float:
+    def native_value(self) -> float:
         return self._device.overrule_setpoint
 
     def on_change(self):

--- a/custom_components/nhc2/entities/hvacthermostat_hvac_overrule_time.py
+++ b/custom_components/nhc2/entities/hvacthermostat_hvac_overrule_time.py
@@ -44,7 +44,7 @@ class Nhc2HvacthermostatHvacOverruleTimeEntity(SensorEntity):
         }
 
     @property
-    def state(self) -> int:
+    def native_value(self) -> int:
         return self._device.overrule_time
 
     def on_change(self):

--- a/custom_components/nhc2/entities/hvacthermostat_hvac_setpoint_temperature.py
+++ b/custom_components/nhc2/entities/hvacthermostat_hvac_setpoint_temperature.py
@@ -26,6 +26,7 @@ class Nhc2HvacthermostatHvacSetpointTemperatureEntity(SensorEntity):
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
         self._attr_state_class = None
         self._attr_suggested_display_precision = 1
+        self._attr_native_precision = 1
 
     @property
     def name(self) -> str:

--- a/custom_components/nhc2/entities/hvacthermostat_hvac_setpoint_temperature.py
+++ b/custom_components/nhc2/entities/hvacthermostat_hvac_setpoint_temperature.py
@@ -45,7 +45,7 @@ class Nhc2HvacthermostatHvacSetpointTemperatureEntity(SensorEntity):
         }
 
     @property
-    def state(self) -> float:
+    def native_value(self) -> float:
         return self._device.setpoint_temperature
 
     def on_change(self):

--- a/custom_components/nhc2/entities/naso_smartplug_electrical_power.py
+++ b/custom_components/nhc2/entities/naso_smartplug_electrical_power.py
@@ -25,7 +25,7 @@ class Nhc2NasoSmartplugElectricalPowerEntity(SensorEntity):
         self._attr_native_value = self._device.electrical_power
         self._attr_native_unit_of_measurement = UnitOfPower.WATT
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_suggested_display_precision = 0
+        self._attr_suggested_display_precision = 3
 
     @property
     def name(self) -> str:

--- a/custom_components/nhc2/entities/naso_smartplug_electrical_power.py
+++ b/custom_components/nhc2/entities/naso_smartplug_electrical_power.py
@@ -26,6 +26,7 @@ class Nhc2NasoSmartplugElectricalPowerEntity(SensorEntity):
         self._attr_native_unit_of_measurement = UnitOfPower.WATT
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_suggested_display_precision = 3
+        self._attr_native_precision = 3
 
     @property
     def name(self) -> str:

--- a/custom_components/nhc2/entities/naso_smartplug_electrical_power.py
+++ b/custom_components/nhc2/entities/naso_smartplug_electrical_power.py
@@ -45,7 +45,7 @@ class Nhc2NasoSmartplugElectricalPowerEntity(SensorEntity):
         }
 
     @property
-    def state(self) -> float:
+    def native_value(self) -> float:
         return self._device.electrical_power
 
     def on_change(self):

--- a/custom_components/nhc2/entities/thermostat_hvac_overrule_setpoint.py
+++ b/custom_components/nhc2/entities/thermostat_hvac_overrule_setpoint.py
@@ -45,7 +45,7 @@ class Nhc2ThermostatHvacOverruleSetpointEntity(SensorEntity):
         }
 
     @property
-    def state(self) -> float:
+    def native_value(self) -> float:
         return self._device.overrule_setpoint
 
     def on_change(self):

--- a/custom_components/nhc2/entities/thermostat_hvac_overrule_setpoint.py
+++ b/custom_components/nhc2/entities/thermostat_hvac_overrule_setpoint.py
@@ -26,6 +26,7 @@ class Nhc2ThermostatHvacOverruleSetpointEntity(SensorEntity):
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
         self._attr_state_class = None
         self._attr_suggested_display_precision = 1
+        self._attr_native_precision = 1
 
     @property
     def name(self) -> str:

--- a/custom_components/nhc2/entities/thermostat_hvac_overrule_time.py
+++ b/custom_components/nhc2/entities/thermostat_hvac_overrule_time.py
@@ -44,7 +44,7 @@ class Nhc2ThermostatHvacOverruleTimeEntity(SensorEntity):
         }
 
     @property
-    def state(self) -> int:
+    def native_value(self) -> int:
         return self._device.overrule_time
 
     def on_change(self):

--- a/custom_components/nhc2/entities/thermostat_hvac_setpoint_temperature.py
+++ b/custom_components/nhc2/entities/thermostat_hvac_setpoint_temperature.py
@@ -45,7 +45,7 @@ class Nhc2ThermostatHvacSetpointTemperatureEntity(SensorEntity):
         }
 
     @property
-    def state(self) -> float:
+    def native_value(self) -> float:
         return self._device.setpoint_temperature
 
     def on_change(self):

--- a/custom_components/nhc2/entities/thermostat_hvac_setpoint_temperature.py
+++ b/custom_components/nhc2/entities/thermostat_hvac_setpoint_temperature.py
@@ -26,6 +26,7 @@ class Nhc2ThermostatHvacSetpointTemperatureEntity(SensorEntity):
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
         self._attr_state_class = None
         self._attr_suggested_display_precision = 1
+        self._attr_native_precision = 1
 
     @property
     def name(self) -> str:

--- a/custom_components/nhc2/entities/thermostat_thermostat_overrule_setpoint.py
+++ b/custom_components/nhc2/entities/thermostat_thermostat_overrule_setpoint.py
@@ -26,6 +26,7 @@ class Nhc2ThermostatThermostatOverruleSetpointEntity(SensorEntity):
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
         self._attr_state_class = None
         self._attr_suggested_display_precision = 1
+        self._attr_native_precision = 1
 
     @property
     def name(self) -> str:

--- a/custom_components/nhc2/entities/thermostat_thermostat_overrule_setpoint.py
+++ b/custom_components/nhc2/entities/thermostat_thermostat_overrule_setpoint.py
@@ -45,7 +45,7 @@ class Nhc2ThermostatThermostatOverruleSetpointEntity(SensorEntity):
         }
 
     @property
-    def state(self) -> float:
+    def native_value(self) -> float:
         return self._device.overrule_setpoint
 
     def on_change(self):

--- a/custom_components/nhc2/entities/thermostat_thermostat_overrule_time.py
+++ b/custom_components/nhc2/entities/thermostat_thermostat_overrule_time.py
@@ -44,7 +44,7 @@ class Nhc2ThermostatThermostatOverruleTimeEntity(SensorEntity):
         }
 
     @property
-    def state(self) -> int:
+    def native_value(self) -> int:
         return self._device.overrule_time
 
     def on_change(self):

--- a/custom_components/nhc2/entities/thermostat_thermostat_setpoint_temperature.py
+++ b/custom_components/nhc2/entities/thermostat_thermostat_setpoint_temperature.py
@@ -45,7 +45,7 @@ class Nhc2ThermostatThermostatSetpointTemperatureEntity(SensorEntity):
         }
 
     @property
-    def state(self) -> float:
+    def native_value(self) -> float:
         return self._device.setpoint_temperature
 
     def on_change(self):

--- a/custom_components/nhc2/entities/thermostat_thermostat_setpoint_temperature.py
+++ b/custom_components/nhc2/entities/thermostat_thermostat_setpoint_temperature.py
@@ -26,6 +26,7 @@ class Nhc2ThermostatThermostatSetpointTemperatureEntity(SensorEntity):
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
         self._attr_state_class = None
         self._attr_suggested_display_precision = 1
+        self._attr_native_precision = 1
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
Changing the Unit of Measurement in the interface had no effect on the value
The SensorEntities are now using `native_value` instead of `state`. Which fixes the issue.

While at it: I fixed the precision for some entities.