### PR TITLE
85 Fix Renson Generic Ventilation Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,10 +360,13 @@ This is exposed as a fan entity.
 
 #### Entities
 
-* **Boost Switch**, enable/disable boost mode.
+* **Boost Switch**, (only if supported), enable/disable boost mode.
 * **CO2 Sensor**, (only if supported), the CO2 level.
 * **Humidity Sensor**, (only if supported), the humidity level.
 * **Coupling Status Enum Sensor**, (only if supported), the connectivity status of the system.
+
+__Remark:__ Some ventilation systems can not be turned off. Home Assistant Fan Entity does not support this. This means
+you will be able to turn it off in Home Assistant, but this will not have any effect.
 
 ### Generic Heating/Cooling Implementation
 

--- a/custom_components/nhc2/entities/generic_fan_fan.py
+++ b/custom_components/nhc2/entities/generic_fan_fan.py
@@ -96,7 +96,6 @@ class Nhc2GenericFanFanEntity(FanEntity):
         self.on_change()
 
     async def async_set_percentage(self, percentage: int) -> None:
-        _LOGGER.error(f'async_set_percentage: {percentage}')
         if self._device.is_fan_speed_range:
             self._device.set_fan_speed(self._gateway, percentage)
         else:

--- a/custom_components/nhc2/entities/generic_fan_fan.py
+++ b/custom_components/nhc2/entities/generic_fan_fan.py
@@ -94,7 +94,11 @@ class Nhc2GenericFanFanEntity(FanEntity):
         self.on_change()
 
     async def async_turn_on(self, speed: str = None, percentage: int = None, preset_mode: str = None, **kwargs) -> None:
-        self._device.set_status(self._gateway, True)
+        if not self._device.supports_status:
+            _LOGGER.info('Device does not support the status property, therefor we can not set any status.')
+        else:
+            self._device.set_status(self._gateway, True)
+
         if percentage is not None and self._device.is_fan_speed_range:
             self._device.set_fan_speed(self._gateway, percentage)
         if preset_mode is not None and self._device.supports_program:
@@ -102,5 +106,8 @@ class Nhc2GenericFanFanEntity(FanEntity):
         self.on_change()
 
     async def async_turn_off(self, **kwargs) -> None:
+        if not self._device.supports_status:
+            _LOGGER.info('Device does not support the status property, therefor we can not set any status.')
+            return
         self._device.set_status(self._gateway, False)
         self.on_change()

--- a/custom_components/nhc2/nhccoco/devices/generic_fan.py
+++ b/custom_components/nhc2/nhccoco/devices/generic_fan.py
@@ -46,6 +46,10 @@ class CocoGenericFan(CoCoDevice):
         return 'Range' in self.extract_property_definition(PROPERTY_FAN_SPEED)['Description']
 
     @property
+    def supports_boost(self) -> bool:
+        return self.has_property(PROPERTY_BOOST)
+
+    @property
     def boost(self) -> str:
         return self.extract_property_value(PROPERTY_BOOST)
 

--- a/custom_components/nhc2/nhccoco/devices/generic_fan.py
+++ b/custom_components/nhc2/nhccoco/devices/generic_fan.py
@@ -58,11 +58,18 @@ class CocoGenericFan(CoCoDevice):
         return self.boost == PROPERTY_BOOST_VALUE_TRUE
 
     @property
+    def supports_status(self) -> bool:
+        return self.has_property(PROPERTY_STATUS)
+
+    @property
     def status(self) -> str:
         return self.extract_property_value(PROPERTY_STATUS)
 
     @property
     def is_status_on(self) -> bool:
+        # Assume status is on if no status property is available
+        if not self.has_property(PROPERTY_STATUS):
+            return True
         return self.status == PROPERTY_STATUS_VALUE_ON
 
     @property

--- a/custom_components/nhc2/switch.py
+++ b/custom_components/nhc2/switch.py
@@ -228,7 +228,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     if len(device_instances) > 0:
         entities = []
         for device_instance in device_instances:
-            entities.append(Nhc2GenericFanBoostEntity(device_instance, hub, gateway))
+            if device_instance.supports_boost:
+                entities.append(Nhc2GenericFanBoostEntity(device_instance, hub, gateway))
 
         async_add_entities(entities)
 


### PR DESCRIPTION
This will be a more robust, although probably not final, implementation for the Generic Ventilation Implementation.

The changes were made based on a Renson Ventilation system. See https://github.com/joleys/niko-home-control-II/issues/95 for more information.

This PR introduces some changes:
* Boost switch will only be present if the `Boost` property is exposed.
*  Implementations that expose FanSpeed as a choice instead of range will
  *  expose these options as presets.
  * will be able to set the fan speed, these will be mapped to these choices
* Fan will be always on if the `Status` property is not exposed. Probably means the ventilation system can't be switched off.