### PR TITLE
Fix exception when electrical power is not available for a clamp

### DIFF
--- a/custom_components/nhc2/entities/electricity_clamp_centralmeter_electrical_power_consumption.py
+++ b/custom_components/nhc2/entities/electricity_clamp_centralmeter_electrical_power_consumption.py
@@ -47,7 +47,7 @@ class Nhc2ElectricityClampCentralmeterElectricalPowerConsumptionEntity(SensorEnt
 
     @property
     def native_value(self) -> float:
-        if self._device.electrical_power > 0:
+        if self._device.electrical_power is not None and self._device.electrical_power > 0:
             return self._device.electrical_power
 
         return 0

--- a/custom_components/nhc2/entities/electricity_clamp_centralmeter_electrical_power_production.py
+++ b/custom_components/nhc2/entities/electricity_clamp_centralmeter_electrical_power_production.py
@@ -47,7 +47,7 @@ class Nhc2ElectricityClampCentralmeterElectricalPowerProductionEntity(SensorEnti
 
     @property
     def native_value(self) -> float:
-        if self._device.electrical_power < 0:
+        if self._device.electrical_power is not None and self._device.electrical_power < 0:
             return -self._device.electrical_power
 
         return 0


### PR DESCRIPTION
2023-12-16 12:34:43.308 ERROR (MainThread) [homeassistant.components.sensor] Error adding entities for domain sensor with platform nhc2
Traceback (most recent call last):
File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 509, in async_add_entities
await asyncio.gather(*tasks)
File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 754, in _async_add_entity
await entity.add_to_platform_finish()
File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1025, in add_to_platform_finish
self.async_write_ha_state()
File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 745, in async_write_ha_state
self._async_write_ha_state()
File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 845, in _async_write_ha_state
state, attr = self._async_generate_attributes()
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 786, in _async_generate_attributes
state = self._stringify_state(available)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 751, in _stringify_state
if (state := self.state) is None:
^^^^^^^^^^
File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 501, in state
value = self.native_value
^^^^^^^^^^^^^^^^^
File "/config/custom_components/nhc2/entities/electricity_clamp_centralmeter_electrical_power_consumption.py", line 50, in native_value
if self._device.electrical_power > 0:
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'NoneType' and 'int'