### PR TITLE
Switch from deprecated TIME_MINUTES to UnitOfTime.MINUTES

### DIFF
--- a/custom_components/nhc2/entities/hvacthermostat_hvac_overrule_time.py
+++ b/custom_components/nhc2/entities/hvacthermostat_hvac_overrule_time.py
@@ -1,5 +1,5 @@
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
-from homeassistant.const import TIME_MINUTES
+from homeassistant.const import UnitOfTime
 
 from ..const import DOMAIN, BRAND
 
@@ -23,7 +23,7 @@ class Nhc2HvacthermostatHvacOverruleTimeEntity(SensorEntity):
 
         self._attr_device_class = SensorDeviceClass.DURATION
         self._attr_native_value = self._device.overrule_time
-        self._attr_native_unit_of_measurement = TIME_MINUTES
+        self._attr_native_unit_of_measurement = UnitOfTime.MINUTES
         self._attr_state_class = None
 
     @property

--- a/custom_components/nhc2/entities/thermostat_hvac_overrule_time.py
+++ b/custom_components/nhc2/entities/thermostat_hvac_overrule_time.py
@@ -1,5 +1,5 @@
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
-from homeassistant.const import TIME_MINUTES
+from homeassistant.const import UnitOfTime
 
 from ..const import DOMAIN, BRAND
 
@@ -23,7 +23,7 @@ class Nhc2ThermostatHvacOverruleTimeEntity(SensorEntity):
 
         self._attr_device_class = SensorDeviceClass.DURATION
         self._attr_native_value = self._device.overrule_time
-        self._attr_native_unit_of_measurement = TIME_MINUTES
+        self._attr_native_unit_of_measurement = UnitOfTime.MINUTES
         self._attr_state_class = None
 
     @property

--- a/custom_components/nhc2/entities/thermostat_thermostat_overrule_time.py
+++ b/custom_components/nhc2/entities/thermostat_thermostat_overrule_time.py
@@ -1,5 +1,5 @@
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
-from homeassistant.const import TIME_MINUTES
+from homeassistant.const import UnitOfTime
 
 from ..const import DOMAIN, BRAND
 
@@ -23,7 +23,7 @@ class Nhc2ThermostatThermostatOverruleTimeEntity(SensorEntity):
 
         self._attr_device_class = SensorDeviceClass.DURATION
         self._attr_native_value = self._device.overrule_time
-        self._attr_native_unit_of_measurement = TIME_MINUTES
+        self._attr_native_unit_of_measurement = UnitOfTime.MINUTES
         self._attr_state_class = None
 
     @property


### PR DESCRIPTION
I've noticed the following warning in HASS:

```
2024-01-15 22:14:02.684 WARNING (MainThread) [homeassistant.const] TIME_MINUTES was used from nhc2, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTime.MINUTES instead, please create a bug report at https://github.com/joleys/niko-home-control-II/issues                                                                                                                                                                                                                                                                                  2024-01-15 22:14:02.696 WARNING (MainThread) [homeassistant.const] TIME_MINUTES was used from nhc2, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTime.MINUTES instead, please create a bug report at https://github.com/joleys/niko-home-control-II/issues                                                                                                                                                                                                                                                                                  2024-01-15 22:14:02.705 WARNING (MainThread) [homeassistant.const] TIME_MINUTES was used from nhc2, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTime.MINUTES instead, please create a bug report at https://github.com/joleys/niko-home-control-II/issues      
```

Changes made to switch from the "in the near future" deprecated TIME_MINUTES to UnitOfTime.MINUTES.
In order to help out on this nice component, I hope this PR brings a nice contribution.
