### PR TITLE
Wrap `dev_reg.async_get_or_create` with `hass.add_job`

### DIFF
--- a/custom_components/nhc2/__init__.py
+++ b/custom_components/nhc2/__init__.py
@@ -93,17 +93,20 @@ async def async_setup_entry(hass, entry):
             coco_image, nhc_version = extract_versions(nhc2_sysinfo)
             _LOGGER.debug('systeminfo.published: NhcVersion: %s - CocoImage %s', nhc_version, coco_image)
 
-            dev_reg.async_get_or_create(
-                config_entry_id=entry.entry_id,
-                connections=set(),
-                identifiers={
-                    (DOMAIN, entry.data[CONF_USERNAME])
-                },
-                manufacturer=BRAND,
-                name='Home Control II',
-                model='Connected controller',
-                sw_version=nhc_version + ' - CoCo Image: ' + coco_image,
-            )
+            def get_or_create_device():
+                return dev_reg.async_get_or_create(
+                    config_entry_id=entry.entry_id,
+                    connections=set(),
+                    identifiers={
+                        (DOMAIN, entry.data[CONF_USERNAME])
+                    },
+                    manufacturer=BRAND,
+                    name='Home Control II',
+                    model='Connected controller',
+                    sw_version=nhc_version + ' - CoCo Image: ' + coco_image,
+                )
+
+            hass.add_job(get_or_create_device)
 
             for platform in FORWARD_PLATFORMS:
                 hass.add_job(

--- a/custom_components/nhc2/__init__.py
+++ b/custom_components/nhc2/__init__.py
@@ -93,7 +93,7 @@ async def async_setup_entry(hass, entry):
             coco_image, nhc_version = extract_versions(nhc2_sysinfo)
             _LOGGER.debug('systeminfo.published: NhcVersion: %s - CocoImage %s', nhc_version, coco_image)
 
-            def get_or_create_device():
+            async def get_or_create_device():
                 return dev_reg.async_get_or_create(
                     config_entry_id=entry.entry_id,
                     connections=set(),
@@ -106,7 +106,7 @@ async def async_setup_entry(hass, entry):
                     sw_version=nhc_version + ' - CoCo Image: ' + coco_image,
                 )
 
-            hass.add_job(get_or_create_device)
+            hass.add_job(get_or_create_device())
 
             for platform in FORWARD_PLATFORMS:
                 hass.add_job(


### PR DESCRIPTION
Makes it so the eventual call to [`device_registry.async_update_device()`](https://github.com/home-assistant/core/blob/cbf853a84f8dbcef5694dd7777f1e75f37bbb2e3/homeassistant/core.py#L559) is executed on the event loop. See `HomeAssistant.add_job()`. Related to #136 / #137.

Fixes #139 .