### PR TITLE
Repair flow when Hobby API Password has expired or the authentication fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ scenes.yaml
 scripts.yaml
 secrets.yaml
 debugging
+
+# Local python venv
+bin
+lib
+pyvenv.cfg

--- a/custom_components/nhc2/__init__.py
+++ b/custom_components/nhc2/__init__.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD, CONF_ADDRESS, CONF_PORT
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
-from homeassistant.helpers import device_registry
+from homeassistant.helpers import device_registry, issue_registry
 
 from .config_flow import Nhc2FlowHandler  # noqa  pylint_disable=unused-import
 from .const import DOMAIN, KEY_GATEWAY, BRAND
@@ -127,7 +127,15 @@ async def async_setup_entry(hass, entry):
 
         if connection_result == 5:
             coco.disconnect()
-            entry.async_start_reauth(hass)
+            issue_registry.create_issue(
+                hass,
+                DOMAIN,
+                "not_authorised",
+                is_fixable=True,
+                severity=issue_registry.IssueSeverity.ERROR,
+                translation_key="not_authorised",
+                data={'entry': entry}
+            )
 
     hass.data.setdefault(KEY_GATEWAY, {})[entry.entry_id] = coco
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, on_hass_stop)

--- a/custom_components/nhc2/config_flow.py
+++ b/custom_components/nhc2/config_flow.py
@@ -1,14 +1,12 @@
 """Config flow to configure component."""
-import logging
-
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.const import CONF_HOST, CONF_USERNAME, \
-    CONF_PASSWORD, CONF_ADDRESS, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD, CONF_ADDRESS, CONF_PORT
 from .nhccoco.coco_discover_profiles import CoCoDiscoverProfiles
 from .nhccoco.coco_login_validation import CoCoLoginValidation
+from .const import DOMAIN
 
-from .const import DOMAIN, KEY_MANUAL
+import logging
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -134,33 +132,5 @@ class Nhc2FlowHandler(config_entries.ConfigFlow):
             data_schema=vol.Schema({
                 vol.Required(CONF_USERNAME, default=first): vol.In(profile_listing),
                 vol.Required(CONF_PASSWORD, default=None): str
-            }),
-        )
-
-    async def async_step_reauth(self, user_input=None):
-        return await self.async_step_reauth_confirm()
-
-    async def async_step_reauth_confirm(self, user_input=None):
-        config_entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
-
-        if user_input is not None:
-            data = config_entry.data.copy()
-            data[CONF_PASSWORD] = user_input[CONF_PASSWORD]
-
-            validator = CoCoLoginValidation(data[CONF_HOST], data[CONF_USERNAME], data[CONF_PASSWORD], data[CONF_PORT])
-            check = await validator.check_connection()
-
-            if check > 0:
-                _LOGGER.error("Authentication failed: %d", check)
-                self._errors["base"] = ("login_check_fail_%d" % check)
-            else:
-                self.hass.config_entries.async_update_entry(config_entry, data=data)
-                return self.async_abort(reason="reauth_successful")
-
-        return self.async_show_form(
-            step_id="reauth_confirm",
-            errors=self._errors,
-            data_schema=vol.Schema({
-                vol.Required(CONF_PASSWORD, default=None): str,
             }),
         )

--- a/custom_components/nhc2/repairs.py
+++ b/custom_components/nhc2/repairs.py
@@ -1,0 +1,58 @@
+import voluptuous as vol
+
+from homeassistant import data_entry_flow
+from homeassistant.components.homeassistant import SERVICE_HOMEASSISTANT_RESTART
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD, CONF_PORT
+from homeassistant.core import HomeAssistant
+
+from .nhccoco.coco_login_validation import CoCoLoginValidation
+
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class NotAuthorisedRepairFlow(RepairsFlow):
+    def __init__(self):
+        self._errors = {}
+
+    async def async_step_init(self, user_input: dict[str, str] | None = None) -> data_entry_flow.FlowResult:
+        return await (self.async_step_confirm())
+
+    async def async_step_confirm(self, user_input: dict[str, str] | None = None) -> data_entry_flow.FlowResult:
+        if user_input is not None:
+            config_entry = self.data['entry']
+            data = config_entry.data.copy()
+            data[CONF_PASSWORD] = user_input[CONF_PASSWORD]
+
+            validator = CoCoLoginValidation(data[CONF_HOST], data[CONF_USERNAME], data[CONF_PASSWORD], data[CONF_PORT])
+            check = await validator.check_connection()
+
+            if check > 0:
+                _LOGGER.error("Authentication failed: %d", check)
+                self._errors["base"] = ("login_check_fail_%d" % check)
+            else:
+                self.hass.config_entries.async_update_entry(config_entry, data=data)
+                await self.hass.services.async_call(
+                    "homeassistant",
+                    SERVICE_HOMEASSISTANT_RESTART,
+                )
+                return self.async_create_entry(data={})
+
+        return self.async_show_form(
+            step_id="confirm",
+            errors=self._errors,
+            data_schema=vol.Schema({
+                vol.Required(CONF_PASSWORD, default=None): str,
+            })
+        )
+
+
+async def async_create_fix_flow(
+        hass: HomeAssistant,
+        issue_id: str,
+        data: dict[str, str | int | float | None] | None,
+) -> RepairsFlow:
+    if issue_id == "not_authorised":
+        return NotAuthorisedRepairFlow()

--- a/custom_components/nhc2/strings.json
+++ b/custom_components/nhc2/strings.json
@@ -44,5 +44,28 @@
       "login_check_fail_4": "Connection refused - bad username or password",
       "login_check_fail_5": "Connection refused - not authorised"
     }
+  },
+  "issues": {
+    "not_authorised": {
+      "title": "Authentication failed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Authentication failed",
+            "description": "We could not authenticate with the given credentials.\n\nProbably your Niko Hobby API has expired. Please retrieve a new password via the Connected Services in the Niko Home Control programming software.\n\nHome Assistant will be restarted afterwards.",
+            "data": {
+              "password": "Password"
+            }
+          }
+        },
+        "error": {
+          "login_check_fail_1": "Connection refused - incorrect protocol version",
+          "login_check_fail_2": "Connection refused - invalid client identifier",
+          "login_check_fail_3": "Connection refused - server unavailable",
+          "login_check_fail_4": "Connection refused - bad username or password",
+          "login_check_fail_5": "Connection refused - not authorised"
+        }
+      }
+    }
   }
 }

--- a/custom_components/nhc2/strings.json
+++ b/custom_components/nhc2/strings.json
@@ -23,19 +23,11 @@
         "data": {
           "host": "Address/IP"
         }
-      },
-      "reauth_confirm": {
-        "title": "Niko Hobby API password expired for Niko Connected Controller II",
-        "description": "The password for the Niko Hobby API has expired. Please retrieve a new password at [My Niko Home Control →  Connected services](https://mynikohomecontrol.niko.eu/enus/ConnectedServices/Overview).\nIf you have stored the key in a `configuration.yaml` file you should change it there.",
-        "data": {
-          "password": "Password"
-        }
       }
     },
     "abort": {
       "single_instance_allowed": "This controller and profile was already added. You can only add it once.",
-      "no_controller_found": "No controller was found.",
-      "reauth_successful": "Authentication successful. [Restart Home Assistant](/config/system) to apply the changes."
+      "no_controller_found": "No controller was found."
     },
     "error": {
       "login_check_fail_1": "Connection refused - incorrect protocol version",

--- a/custom_components/nhc2/translations/en.json
+++ b/custom_components/nhc2/translations/en.json
@@ -44,5 +44,28 @@
       "login_check_fail_4": "Connection refused - bad username or password",
       "login_check_fail_5": "Connection refused - not authorised"
     }
+  },
+  "issues": {
+    "not_authorised": {
+      "title": "Authentication failed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Authentication failed",
+            "description": "We could not authenticate with the given credentials.\n\nProbably your Niko Hobby API has expired. Please retrieve a new password via the Connected Services in the Niko Home Control programming software.\n\nHome Assistant will be restarted afterwards.",
+            "data": {
+              "password": "Password"
+            }
+          }
+        },
+        "error": {
+          "login_check_fail_1": "Connection refused - incorrect protocol version",
+          "login_check_fail_2": "Connection refused - invalid client identifier",
+          "login_check_fail_3": "Connection refused - server unavailable",
+          "login_check_fail_4": "Connection refused - bad username or password",
+          "login_check_fail_5": "Connection refused - not authorised"
+        }
+      }
+    }
   }
 }

--- a/custom_components/nhc2/translations/en.json
+++ b/custom_components/nhc2/translations/en.json
@@ -23,19 +23,11 @@
         "data": {
           "host": "Address/IP"
         }
-      },
-      "reauth_confirm": {
-        "title": "Niko Hobby API password expired for Niko Connected Controller II",
-        "description": "The password for the Niko Hobby API has expired. Please retrieve a new password at [My Niko Home Control →  Connected services](https://mynikohomecontrol.niko.eu/enus/ConnectedServices/Overview).\nIf you have stored the key in a `configuration.yaml` file you should change it there.",
-        "data": {
-          "password": "Password"
-        }
       }
     },
     "abort": {
       "single_instance_allowed": "This controller and profile was already added. You can only add it once.",
-      "no_controller_found": "No controller was found.",
-      "reauth_successful": "Authentication successful. [Restart Home Assistant](/config/system) to apply the changes."
+      "no_controller_found": "No controller was found."
     },
     "error": {
       "login_check_fail_1": "Connection refused - incorrect protocol version",

--- a/custom_components/nhc2/translations/nl.json
+++ b/custom_components/nhc2/translations/nl.json
@@ -44,5 +44,28 @@
       "login_check_fail_4": "Verbinding geweigerd - onjuiste gebruikersnaam of wachtwoord",
       "login_check_fail_5": "Verbinding geweigerd - niet geautoriseerd"
     }
+  },
+  "issues": {
+    "not_authorised": {
+      "title": "Niet geautoriseerd",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Niet geautoriseerd",
+            "description": "De loginggegevens gaven een fout.\n\nVermoedelijk is je Niko Hobby API wachtwoord verlopen. Haal een nieuw wachtwoord op via Geconnecteerde services in de Niko Home Control programming software.\n\nHome Assistant zal nadien herstart worden.",
+            "data": {
+              "password": "Password"
+            }
+          }
+        },
+        "error": {
+          "login_check_fail_1": "Verbinding geweigerd - onjuiste protocolversie",
+          "login_check_fail_2": "Verbinding geweigerd - ongeldige client-ID",
+          "login_check_fail_3": "Verbinding geweigerd - server niet beschikbaar",
+          "login_check_fail_4": "Verbinding geweigerd - onjuiste gebruikersnaam of wachtwoord",
+          "login_check_fail_5": "Verbinding geweigerd - niet geautoriseerd"
+        }
+      }
+    }
   }
 }

--- a/custom_components/nhc2/translations/nl.json
+++ b/custom_components/nhc2/translations/nl.json
@@ -23,19 +23,11 @@
         "data": {
           "host": "Adres/IP"
         }
-      },
-      "reauth_confirm": {
-        "title": "Het wachtwoord is verlopen voor Niko Connected Controller II",
-        "description": "Het wachtwoord voor de Niko Hobby API is verlopen. Haal een nieuw wachtwoord op via [My Niko Home Control →  Geconnecteerde services](https://mynikohomecontrol.niko.eu/nlbe/ConnectedServices/Overview).\nHeb je het het geconfigureerd via `configuration.yaml` dan moet je het daar aanpassen.",
-        "data": {
-          "password": "Wachtwoord"
-        }
       }
     },
     "abort": {
       "single_instance_allowed": "Deze controller en profiel zijn reeds toegevoegd. Je kan deze geen 2 keer toevoegen.",
       "no_controller_found": "Geen controller gevonden.",
-      "reauth_successful": "Authenticatie geslaagd. [Herstart Home Assistant](/config/system) om de nieuwe instellingen te laden."
     },
     "error": {
       "login_check_fail_1": "Verbinding geweigerd - onjuiste protocolversie",


### PR DESCRIPTION
When the authentication to the Niko Home Controller fails, for instance when the Hobby API password has expired, an Issue will be created in Home Assistant. 

This will show a warning in the interface. The issue can be repaired by entering the new password.

See https://github.com/joleys/niko-home-control-II/issues/148