### PR TITLE
getmac is no requirement anymore

### DIFF
--- a/custom_components/nhc2/manifest.json
+++ b/custom_components/nhc2/manifest.json
@@ -13,8 +13,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/joleys/niko-home-control-II/issues",
   "requirements": [
-    "paho-mqtt==1.6.1",
-    "getmac==0.8.3"
+    "paho-mqtt==1.6.1"
   ],
   "version": "v4.3.0"
 }


### PR DESCRIPTION
Probably needs some testing. But as HACS handles these requirements I don't know a good way to test.