### PR TITLE
Update nl.json

### DIFF
--- a/custom_components/nhc2/translations/nl.json
+++ b/custom_components/nhc2/translations/nl.json
@@ -27,7 +27,7 @@
     },
     "abort": {
       "single_instance_allowed": "Deze controller en profiel zijn reeds toegevoegd. Je kan deze geen 2 keer toevoegen.",
-      "no_controller_found": "Geen controller gevonden.",
+      "no_controller_found": "Geen controller gevonden."
     },
     "error": {
       "login_check_fail_1": "Verbinding geweigerd - onjuiste protocolversie",


### PR DESCRIPTION
solves the following error:
homeassistant.exceptions.HomeAssistantError: Error while loading /home/homeassistant/.homeassistant/custom_components/nhc2/translations/nl.json: trailing comma is not allowed: line 31 column 6 (char 1537)