### PR TITLE
Disabled detecting the Touch profiles as it fails completly in HA 2024.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ You can use a touchscreen profile or the Hobby API account.
 This integration communicates directly with the controller. You only need internet when activating/renewing the Hobby
 API. If you use a touch screen profile, this isn't even needed.
 
+**IMPORTANT**: There is an issue with the touch profiles, so the only supported way to configure the controller is the
+Niko Hobby API.
+
 ## Acknowledgements
 
 This custom component is a [spin-off of the hard and excellent work by @filipvh](https://github.com/filipvh/hass-nhc2).

--- a/custom_components/nhc2/config_flow.py
+++ b/custom_components/nhc2/config_flow.py
@@ -92,11 +92,21 @@ class Nhc2FlowHandler(config_entries.ConfigFlow):
     async def async_step_manual_host(self, user_input=None):
         self._errors = {}
 
-        disc = CoCoDiscoverProfiles(user_input[CONF_HOST])
-        self._all_cocos = await disc.get_all_profiles()
+        # Disabled for now, as it goes wrong in HA 2024.7.x
+        # See https://github.com/joleys/niko-home-control-II/issues/168 for more information
+        # disc = CoCoDiscoverProfiles(user_input[CONF_HOST])
+        # self._all_cocos = await disc.get_all_profiles()
+        self._all_cocos = [
+            (
+                user_input[CONF_HOST],
+                None,
+                [],
+                None
+            )
+        ]
+
         if self._all_cocos is not None and len(self._all_cocos) == 1:
             self._selected_coco = self._all_cocos[0]
-            _LOGGER.debug(str(self._all_cocos))
             for coco in self._all_cocos:
                 if coco[2] is None:
                     return self.async_abort(reason="no_controller_found")


### PR DESCRIPTION
Disabled the detection of Niko Touch profiles.

This is a **temporary** fix, which should allow new users that have HA 2024.7 to configure the integration.
This does **not** affect users that have the integration already configured.

See https://github.com/joleys/niko-home-control-II/issues/168 for more information.