### PR TITLE
Add support for Amtron EV charging station

### DIFF
--- a/custom_components/nhc2/nhccoco/coco.py
+++ b/custom_components/nhc2/nhccoco/coco.py
@@ -9,6 +9,7 @@ from .devices.accesscontrol_action import CocoAccesscontrolAction
 from .devices.airco_hvac import CocoAircoHvac
 from .devices.alarms_action import CocoAlarmsAction
 from .devices.alloff_action import CocoAlloffAction
+from .devices.amtron_chargingstation import CocoAmtronChargingstation
 from .devices.audiocontrol_action import CocoAudiocontrolAction
 from .devices.battery_clamp_centralmeter import CocoBatteryClampCentralmeter
 from .devices.bellbutton_action import CocoBellbuttonAction

--- a/custom_components/nhc2/nhccoco/devices/amtron_chargingstation.py
+++ b/custom_components/nhc2/nhccoco/devices/amtron_chargingstation.py
@@ -1,0 +1,5 @@
+from .generic_chargingstation import CocoGenericChargingstation
+
+
+class CocoAmtronChargingstation(CocoGenericChargingstation):
+    pass


### PR DESCRIPTION
Added an alias for Amtron charging stations so they are mapped to the generic chargingstation class. This fixes the "Class  ocoAmtronChargingstation not found" error when the controller reports Model=amtron.

Tested locally with a Mennekes Amtron Pro EV charger and confirmed that entities are created and work as expected in Home Assistant.