### PR TITLE
feat: Ignore CocoAvout010VDimmer as it has no properties

### DIFF
--- a/custom_components/nhc2/nhccoco/coco.py
+++ b/custom_components/nhc2/nhccoco/coco.py
@@ -351,6 +351,7 @@ class CoCo:
                 # * are not supported by the API / MQTT broker
                 # * don't have any (usefull) properties
                 if classname in [
+                    'CocoAvout010VDimmer',
                     'CocoAvout010VFanFan',
                     'CocoAvout110VDimmer',
                     'CocoBatterypoweredmotiondetectorMotiondetector',


### PR DESCRIPTION
Will fix https://github.com/joleys/niko-home-control-II/issues/275