### PR TITLE
fix unable to set target charging distance and target reachable dista…

### DIFF
--- a/custom_components/nhc2/entities/generic_chargingstation_reachable_distance.py
+++ b/custom_components/nhc2/entities/generic_chargingstation_reachable_distance.py
@@ -1,25 +1,24 @@
-from homeassistant.components.number import NumberEntity, NumberDeviceClass
+from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorStateClass
 from homeassistant.const import UnitOfLength
 
 from ..nhccoco.devices.generic_chargingstation import CocoGenericChargingstation
+from ..nhccoco.helpers import to_int_or_none
 from .nhc_entity import NHCBaseEntity
 
 
-class Nhc2GenericChargingstationReachableDistanceEntity(NHCBaseEntity, NumberEntity):
+class Nhc2GenericChargingstationReachableDistanceEntity(NHCBaseEntity, SensorEntity):
     _attr_has_entity_name = True
 
     def __init__(self, device_instance: CocoGenericChargingstation, hub, gateway):
-        """Initialize a number entity."""
+        """Initialize a sensor."""
         super().__init__(device_instance, hub, gateway)
 
         self._attr_unique_id = device_instance.uuid + '_reachable_distance'
 
-        self._attr_device_class = NumberDeviceClass.DISTANCE
-        min_value, max_value, step = self._device.reachable_distance_range
-        self._attr_native_max_value = max_value
-        self._attr_native_min_value = min_value
-        self._attr_native_step = step
+        self._attr_device_class = SensorDeviceClass.DISTANCE
+        self._attr_native_value = to_int_or_none(self._device.reachable_distance)
         self._attr_native_unit_of_measurement = UnitOfLength.KILOMETERS
+        self._attr_state_class = SensorStateClass.MEASUREMENT
 
     @property
     def name(self) -> str:
@@ -27,8 +26,4 @@ class Nhc2GenericChargingstationReachableDistanceEntity(NHCBaseEntity, NumberEnt
 
     @property
     def native_value(self) -> float:
-        return self._device.reachable_distance
-
-    async def async_set_native_value(self, value: float) -> None:
-        self._device.set_reachable_distance(self._gateway, value)
-        self.schedule_update_ha_state()
+        return to_int_or_none(self._device.reachable_distance)

--- a/custom_components/nhc2/nhccoco/devices/generic_chargingstation.py
+++ b/custom_components/nhc2/nhccoco/devices/generic_chargingstation.py
@@ -119,10 +119,6 @@ class CocoGenericChargingstation(CoCoDevice):
         return self.has_property(PROPERTY_REACHABLE_DISTANCE)
 
     @property
-    def reachable_distance_range(self) -> tuple[float, float, float]:
-        return self.extract_property_definition_description_range(PROPERTY_REACHABLE_DISTANCE)
-
-    @property
     def target_reached(self) -> str | None:
         return self.extract_property_value(PROPERTY_TARGET_REACHED)
 

--- a/custom_components/nhc2/nhccoco/devices/generic_chargingstation.py
+++ b/custom_components/nhc2/nhccoco/devices/generic_chargingstation.py
@@ -158,10 +158,10 @@ class CocoGenericChargingstation(CoCoDevice):
             gateway.add_device_control(self.uuid, PROPERTY_BOOST, PROPERTY_BOOST_VALUE_FALSE)
 
     def set_target_distance(self, gateway, target_distance: int):
-        gateway.add_device_control(self.uuid, PROPERTY_TARGET_DISTANCE, target_distance)
+        gateway.add_device_control(self.uuid, PROPERTY_TARGET_DISTANCE, str(int(target_distance)))
 
     def set_target_time(self, gateway, target_time: time):
         gateway.add_device_control(self.uuid, PROPERTY_TARGET_TIME, target_time.strftime('%H:%M'))
 
     def set_reachable_distance(self, gateway, reachable_distance: int):
-        gateway.add_device_control(self.uuid, PROPERTY_REACHABLE_DISTANCE, reachable_distance)
+        gateway.add_device_control(self.uuid, PROPERTY_REACHABLE_DISTANCE, str(int(reachable_distance)))

--- a/custom_components/nhc2/nhccoco/devices/generic_chargingstation.py
+++ b/custom_components/nhc2/nhccoco/devices/generic_chargingstation.py
@@ -162,6 +162,3 @@ class CocoGenericChargingstation(CoCoDevice):
 
     def set_target_time(self, gateway, target_time: time):
         gateway.add_device_control(self.uuid, PROPERTY_TARGET_TIME, target_time.strftime('%H:%M'))
-
-    def set_reachable_distance(self, gateway, reachable_distance: int):
-        gateway.add_device_control(self.uuid, PROPERTY_REACHABLE_DISTANCE, str(int(reachable_distance)))

--- a/custom_components/nhc2/nhccoco/devices/generic_chargingstation.py
+++ b/custom_components/nhc2/nhccoco/devices/generic_chargingstation.py
@@ -162,3 +162,6 @@ class CocoGenericChargingstation(CoCoDevice):
 
     def set_target_time(self, gateway, target_time: time):
         gateway.add_device_control(self.uuid, PROPERTY_TARGET_TIME, target_time.strftime('%H:%M'))
+
+    def set_reachable_distance(self, gateway, reachable_distance: int):
+        gateway.add_device_control(self.uuid, PROPERTY_REACHABLE_DISTANCE, str(int(reachable_distance)))

--- a/custom_components/nhc2/number.py
+++ b/custom_components/nhc2/number.py
@@ -45,7 +45,5 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         for device_instance in device_instances:
             if device_instance.supports_target_distance:
                 entities.append(Nhc2GenericChargingstationTargetDistanceEntity(device_instance, hub, gateway))
-            if device_instance.supports_reachable_distance:
-                entities.append(Nhc2GenericChargingstationReachableDistanceEntity(device_instance, hub, gateway))
 
         async_add_entities(entities)

--- a/custom_components/nhc2/number.py
+++ b/custom_components/nhc2/number.py
@@ -5,7 +5,6 @@ from homeassistant.const import CONF_USERNAME
 
 from .nhccoco.coco import CoCo
 
-from .entities.generic_chargingstation_reachable_distance import Nhc2GenericChargingstationReachableDistanceEntity
 from .entities.generic_chargingstation_target_distance import Nhc2GenericChargingstationTargetDistanceEntity
 from .entities.generic_domestichotwaterunit_domestic_hot_water_temperature import \
     Nhc2GenericDomestichotwaterunitDomesticHotWaterTemperatureEntity

--- a/custom_components/nhc2/sensor.py
+++ b/custom_components/nhc2/sensor.py
@@ -30,6 +30,7 @@ from .entities.generic_chargingstation_coupling_status import Nhc2GenericChargin
 from .entities.generic_chargingstation_electrical_power import Nhc2GenericChargingstationElectricalPowerEntity
 from .entities.generic_chargingstation_ev_status import Nhc2GenericChargingstationEvStatusEntity
 from .entities.generic_chargingstation_next_charging_time import Nhc2GenericChargingstationNextChargingTimeEntity
+from .entities.generic_chargingstation_reachable_distance import Nhc2GenericChargingstationReachableDistanceEntity
 from .entities.generic_domestichotwaterunit_coupling_status import Nhc2GenericDomestichotwaterunitCouplingStatusEntity
 from .entities.generic_energyhome_electrical_power_consumption import \
     Nhc2GenericEnergyhomeElectricalPowerConsumptionEntity
@@ -437,6 +438,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 entities.append(Nhc2GenericChargingstationChargingStatusEntity(device_instance, hub, gateway))
             if device_instance.supports_next_charging_time:
                 entities.append(Nhc2GenericChargingstationNextChargingTimeEntity(device_instance, hub, gateway))
+            if device_instance.supports_reachable_distance:
+                entities.append(Nhc2GenericChargingstationReachableDistanceEntity(device_instance, hub, gateway))
 
         async_add_entities(entities)
 


### PR DESCRIPTION
NHC expects the target and reachable data for car chargers in string format. HA sends integer value.
Casting to string.

validated working on my local home assistant for ABB car charger.

HA sents {"ReachableDistance": 373.0}, expected by NHC {"ReachableDistance": " 373"}