### PR TITLE
fix: replace deprecated CONCENTRATION_PARTS_PER_MILLION constant

### DIFF
--- a/custom_components/nhc2/entities/generic_fan_co2.py
+++ b/custom_components/nhc2/entities/generic_fan_co2.py
@@ -1,5 +1,5 @@
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
-from homeassistant.const import CONCENTRATION_PARTS_PER_MILLION
+from homeassistant.const import UnitOfRatio
 
 from ..nhccoco.devices.generic_fan import CocoGenericFan
 from .nhc_entity import NHCBaseEntity
@@ -16,7 +16,7 @@ class Nhc2GenericFanCo2Entity(NHCBaseEntity, SensorEntity):
 
         self._attr_device_class = SensorDeviceClass.CO2
         self._attr_native_value = self._device.co2
-        self._attr_native_unit_of_measurement = CONCENTRATION_PARTS_PER_MILLION
+        self._attr_native_unit_of_measurement = UnitOfRatio.PARTS_PER_MILLION
         self._attr_suggested_display_precision = 0
         self._attr_native_precision = 0
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,5 @@
 {
   "name": "Niko Home Control II",
-  "render_readme": true
+  "render_readme": true,
+  "homeassistant": "2026.7.0"
 }


### PR DESCRIPTION
## Problem

`CONCENTRATION_PARTS_PER_MILLION` was deprecated in Home Assistant Core 2026.7 in favour of the new `UnitOfRatio` enumerator. Every start now logs:

```
The deprecated constant CONCENTRATION_PARTS_PER_MILLION was used from nhc2.
It will be removed in HA Core 2027.8. Use UnitOfRatio.PARTS_PER_MILLION
instead, please report it to the author of the 'nhc2' custom integration
```

The constant is removed in Core **2027.8**, at which point the CO2 sensor would fail to import.

## Change

One call site, in `entities/generic_fan_co2.py`:

```diff
-from homeassistant.const import CONCENTRATION_PARTS_PER_MILLION
+from homeassistant.const import UnitOfRatio
...
-        self._attr_native_unit_of_measurement = CONCENTRATION_PARTS_PER_MILLION
+        self._attr_native_unit_of_measurement = UnitOfRatio.PARTS_PER_MILLION
```

Both resolve to `"ppm"`, so entity state, unit and recorded statistics are unchanged.

## Minimum Home Assistant version — please review

`UnitOfRatio` only exists from Core **2026.7** onwards, and the repository currently declares no minimum core version in either `hacs.json` or `manifest.json`. Without a floor, this change would raise `ImportError` on older cores and take the whole integration down, which is worse than the warning it replaces. So this PR also adds to `hacs.json`:

```json
"homeassistant": "2026.7.0"
```

That makes HACS withhold the update from users below 2026.7 rather than breaking them.

If you would prefer not to raise the supported floor, the alternative is a fallback import:

```python
try:
    from homeassistant.const import UnitOfRatio
    PPM = UnitOfRatio.PARTS_PER_MILLION
except ImportError:
    from homeassistant.const import CONCENTRATION_PARTS_PER_MILLION as PPM
```

That keeps compatibility with older cores at the cost of carrying dead code until 2027.8. Happy to switch to whichever you prefer.

## Testing

Static checks only — this has **not** been exercised against a live NHC2 installation:

- `python3 -m py_compile` passes on the changed file
- `hacs.json` validated as JSON
- No remaining references to `CONCENTRATION_PARTS_PER_MILLION` in the codebase

The deprecation warning itself was observed in the wild on Core 2026.8, which is what prompted the change.

## References

- [Introducing new unit enumerators](https://developers.home-assistant.io/blog/2026/06/30/new-unit-enumerators/) (HA Developer Docs)
