### PR TITLE
Fix 'NoneType' object has no attribute 'states' on detached entities

### DIFF
--- a/custom_components/nhc2/entities/electricity_clamp_centralmeter_report_instant_usage.py
+++ b/custom_components/nhc2/entities/electricity_clamp_centralmeter_report_instant_usage.py
@@ -32,6 +32,9 @@ class Nhc2ElectricityClampCentralmeterReportInstantUsageEntity(NHCBaseEntity, Bi
     def on_change(self):
         super().on_change()
 
+        if self.hass is None:
+            return
+
         # Re-enable reporting when it is turned off
         if self._device.is_report_instant_usage is False and not self._is_report_instant_usage_re_enabling_disabled():
             self._device.enable_report_instant_usage(self._gateway)

--- a/custom_components/nhc2/entities/generic_energyhome_report_instant_usage.py
+++ b/custom_components/nhc2/entities/generic_energyhome_report_instant_usage.py
@@ -33,6 +33,9 @@ class Nhc2GenericEnergyhomeReportInstantUsageEntity(NHCBaseEntity, BinarySensorE
     def on_change(self):
         super().on_change()
 
+        if self.hass is None:
+            return
+
         # Re-enable reporting when it is turned off
         if self._device.is_report_instant_usage is False and not self._is_report_instant_usage_re_enabling_disabled():
             self._device.enable_report_instant_usage(self._gateway)

--- a/custom_components/nhc2/entities/generic_inverter_report_instant_usage.py
+++ b/custom_components/nhc2/entities/generic_inverter_report_instant_usage.py
@@ -33,6 +33,9 @@ class Nhc2GenericInverterReportInstantUsageEntity(NHCBaseEntity, BinarySensorEnt
     def on_change(self):
         super().on_change()
 
+        if self.hass is None:
+            return
+
         # Re-enable reporting when it is turned off
         if self._device.is_report_instant_usage is False and not self._is_report_instant_usage_re_enabling_disabled():
             self._device.enable_report_instant_usage(self._gateway)

--- a/custom_components/nhc2/entities/generic_smartplug_report_instant_usage.py
+++ b/custom_components/nhc2/entities/generic_smartplug_report_instant_usage.py
@@ -33,6 +33,9 @@ class Nhc2GenericSmartplugReportInstantUsageEntity(NHCBaseEntity, BinarySensorEn
     def on_change(self):
         super().on_change()
 
+        if self.hass is None:
+            return
+
         # Re-enable reporting when it is turned off
         if self._device.is_report_instant_usage is False and not self._is_report_instant_usage_re_enabling_disabled():
             self._device.enable_report_instant_usage(self._gateway)

--- a/custom_components/nhc2/entities/naso_smartplug_feedback_enabled.py
+++ b/custom_components/nhc2/entities/naso_smartplug_feedback_enabled.py
@@ -5,7 +5,7 @@ from ..nhccoco.devices.naso_smartplug import CocoNasoSmartplug
 from .nhc_entity import NHCBaseEntity
 
 
-class Nhc2NasoSmartplugFeedbackEnabledEntity(BinarySensorEntity, NHCBaseEntity):
+class Nhc2NasoSmartplugFeedbackEnabledEntity(NHCBaseEntity, BinarySensorEntity):
     _attr_has_entity_name = True
 
     def __init__(self, device_instance: CocoNasoSmartplug, hub, gateway):

--- a/custom_components/nhc2/entities/naso_smartplug_report_instant_usage.py
+++ b/custom_components/nhc2/entities/naso_smartplug_report_instant_usage.py
@@ -33,6 +33,9 @@ class Nhc2NasoSmartplugReportInstantUsageEntity(NHCBaseEntity, BinarySensorEntit
     def on_change(self):
         super().on_change()
 
+        if self.hass is None:
+            return
+
         # Re-enable reporting when it is turned off
         if self._device.is_report_instant_usage is False and not self._is_report_instant_usage_re_enabling_disabled():
             self._device.enable_report_instant_usage(self._gateway)

--- a/custom_components/nhc2/entities/nhc_entity.py
+++ b/custom_components/nhc2/entities/nhc_entity.py
@@ -10,12 +10,19 @@ class NHCBaseEntity():
         self._hub = hub
         self._gateway = gateway
 
-        self._device.after_change_callbacks.append(self.on_change)
-
         self._attr_available = self._device.is_online
         self._attr_should_poll = False
         self._attr_device_info = self._device.device_info(self._hub)
         self._attr_state_class = None
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self._device.after_change_callbacks.append(self.on_change)
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self.on_change in self._device.after_change_callbacks:
+            self._device.after_change_callbacks.remove(self.on_change)
+        await super().async_will_remove_from_hass()
 
     def on_change(self):
         if self.hass is None:
@@ -23,7 +30,7 @@ class NHCBaseEntity():
             _LOGGER.warning(
                 "NHC2 Entity '%s' (UUID: %s) received an update but is not linked to Home Assistant. "
                 "This usually happens if the device was removed or is still initializing.",
-                self.name, 
+                self.name,
                 self._device.uuid
             )
             return

--- a/custom_components/nhc2/entities/nhc_entity.py
+++ b/custom_components/nhc2/entities/nhc_entity.py
@@ -17,7 +17,8 @@ class NHCBaseEntity():
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
-        self._device.after_change_callbacks.append(self.on_change)
+        if self.on_change not in self._device.after_change_callbacks:
+            self._device.after_change_callbacks.append(self.on_change)
 
     async def async_will_remove_from_hass(self) -> None:
         if self.on_change in self._device.after_change_callbacks:

--- a/custom_components/nhc2/nhccoco/devices/controller.py
+++ b/custom_components/nhc2/nhccoco/devices/controller.py
@@ -31,7 +31,9 @@ class CocoController:
             if self._first_time_devices_list_received is None:
                 self._first_time_devices_list_received = self._last_time_devices_list_received
 
-        for callback in self._after_change_callbacks:
+        # Iterate over a snapshot: entities register/deregister their callbacks
+        # from the HA event loop while this runs on the MQTT thread.
+        for callback in list(self._after_change_callbacks):
             callback()
 
     def set_disconnected(self):

--- a/custom_components/nhc2/nhccoco/devices/device.py
+++ b/custom_components/nhc2/nhccoco/devices/device.py
@@ -172,7 +172,9 @@ class CoCoDevice():
         if DEVICE_DESCRIPTOR_ONLINE in payload:
             self._online = payload[DEVICE_DESCRIPTOR_ONLINE] == DEVICE_DESCRIPTOR_ONLINE_VALUE_TRUE
 
-        for callback in self._after_change_callbacks:
+        # Iterate over a snapshot: entities register/deregister their callbacks
+        # from the HA event loop while this runs on the MQTT thread.
+        for callback in list(self._after_change_callbacks):
             callback()
 
     def set_disconnected(self):


### PR DESCRIPTION
## Problem

Entities register their device `after_change` callback in `NHCBaseEntity.__init__` and never deregister it. The callback therefore keeps firing on entity objects that are not (or no longer) attached to Home Assistant — most commonly entities **disabled in the entity registry** (HA constructs them, then aborts the platform add, leaving `hass = None`), but also entities that were removed, or updates racing in before `async_add_entities` completes.

The `hass is None` guard added in #289 ("Log removed entities") only returns from the **base** method — subclasses that override `on_change` continue right past `super().on_change()` and dereference `self.hass` anyway. Observed on every instant-usage MQTT message after disabling a smart plug's "Report Instant Usage" diagnostic entity:

```
2026-08-21 17:56:44.290 WARNING [custom_components.nhc2.entities.nhc_entity] NHC2 Entity 'Report Instant Usage' (UUID: 5829efe5-…) received an update but is not linked to Home Assistant. …
2026-08-21 17:56:44.290 ERROR [custom_components.nhc2.nhccoco.coco] 'NoneType' object has no attribute 'states'
Traceback (most recent call last):
  File "/config/custom_components/nhc2/nhccoco/coco.py", line 186, in _on_message
    self._device_instances[device[MQTT_DATA_PARAMS_DEVICES_UUID]].on_change(topic, device)
  File "/config/custom_components/nhc2/nhccoco/devices/device.py", line 176, in on_change
    callback()
  File "/config/custom_components/nhc2/entities/naso_smartplug_report_instant_usage.py", line 37, in on_change
    if self._device.is_report_instant_usage is False and not self._is_report_instant_usage_re_enabling_disabled():
  File "/config/custom_components/nhc2/entities/naso_smartplug_report_instant_usage.py", line 45, in _is_report_instant_usage_re_enabling_disabled
    disable_report_instant_usage_re_enabling_entity = self.hass.states.get(
AttributeError: 'NoneType' object has no attribute 'states'
```

## Fix

- Register the callback in `async_added_to_hass` and deregister it in `async_will_remove_from_hass`, so detached entities receive no callbacks at all. This also stops the "received an update but is not linked" warning from #289 at its source; the guard stays as a safety net.
- Add an explicit `if self.hass is None: return` after `super().on_change()` in the five `*_report_instant_usage` entities (naso/generic smartplug, energyhome, inverter, electricity clamp centralmeter), which all share the vulnerable pattern.
- Fix the base-class order of `Nhc2NasoSmartplugFeedbackEnabledEntity` (`BinarySensorEntity, NHCBaseEntity` → `NHCBaseEntity, BinarySensorEntity`) so `Entity`'s no-op lifecycle hooks don't shadow the new registration logic in the MRO.
- Iterate a snapshot of `after_change_callbacks` in `device.py`/`controller.py`, since the list is now mutated from the HA event loop while the paho MQTT thread iterates it.

## Testing

Running on my own installation (HA 2026.8.2, v4.18.0 base + this patch): the error and warning previously fired on every instant-usage message for the disabled entity; after this change the log is clean and the remaining smart plug entities keep updating normally.
