### PR TITLE
Fix one-hour statistics offset under DST

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -16,3 +16,15 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CATEGORY: "integration"
+
+  tests:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v4"
+      - uses: "actions/setup-python@v5"
+        with:
+          python-version: "3.13"
+      - name: Install test dependencies
+        run: pip install -r requirements_test.txt
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ bin
 lib
 pyvenv.cfg
 .DS_Store
+
+# Python
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/custom_components/nhc2/statistics_coordinator.py
+++ b/custom_components/nhc2/statistics_coordinator.py
@@ -12,6 +12,7 @@ from homeassistant.components.recorder.statistics import (
     StatisticMeanType,
 )
 from homeassistant.const import UnitOfEnergy, UnitOfVolume
+from homeassistant.util import dt as dt_util
 
 from .nhccoco.coco import CoCo
 from .nhccoco.measurements_client import MeasurementsClient
@@ -36,23 +37,17 @@ UNIT_CONVERSIONS = {
 }
 
 
+# The measurements API works in the controller's local time: request
+# intervals are interpreted as local time (any UTC offset in the string is
+# ignored) and returned DateTime values are naive local period starts.
+# Align and communicate in HA's configured timezone, convert to UTC only
+# for the recorder.
+
 def align_to_hour(dt: datetime) -> datetime:
-    aligned = dt.replace(minute=0, second=0, microsecond=0)
-    
-    # Ensure timezone info is present (assume UTC if missing)
-    if aligned.tzinfo is None:
-        aligned = aligned.replace(tzinfo=timezone.utc)
-    
-    return aligned
+    return dt_util.as_local(dt).replace(minute=0, second=0, microsecond=0)
 
 def align_to_midnight(dt: datetime) -> datetime:
-    aligned = dt.replace(hour=0, minute=0, second=0, microsecond=0)
-    
-    # Ensure timezone info is present (assume UTC if missing)
-    if aligned.tzinfo is None:
-        aligned = aligned.replace(tzinfo=timezone.utc)
-    
-    return aligned
+    return dt_util.as_local(dt).replace(hour=0, minute=0, second=0, microsecond=0)
 
 class StatisticsCoordinator:
     def __init__(
@@ -162,25 +157,20 @@ class StatisticsCoordinator:
             _LOGGER.info(f"No new data to import for {statistic_id}")
             return None
 
-        if not longterm:
-            start_time = start_time + timedelta(hours=1)
-            end_time = end_time + timedelta(hours=1)
-    
         _LOGGER.debug(f"Importing data from {start_time} to {end_time} for {statistic_id}")
         return start_time, end_time
         
-    def _process_api_values(self, values: list, property_name: str, adjust_hour: bool = False) -> list[dict]:
+    def _process_api_values(self, values: list, property_name: str) -> list[dict]:
         statistics_data = []
-    
+
         for value in values:
             if "DateTime" in value and "Value" in value and value["Value"] is not None:
                 dt = datetime.fromisoformat(value["DateTime"])
                 if dt.tzinfo is None:
-                    dt = dt.replace(tzinfo=timezone.utc)
-    
-                if adjust_hour:
-                    dt = dt - timedelta(hours=1)
-    
+                    # Naive timestamps are local period starts
+                    dt = dt.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
+                dt = dt_util.as_utc(dt)
+
                 val = value["Value"]
                     
                 for key, factor in UNIT_CONVERSIONS.items():
@@ -201,7 +191,6 @@ class StatisticsCoordinator:
         end_time: datetime,
         period: str,
         max_days: int,
-        adjust_hour: bool = False
     ) -> list[dict]:
         _LOGGER.info(f"Fetching {period} aggregated data from {start_time} to {end_time}")
         statistics_data = []
@@ -211,15 +200,21 @@ class StatisticsCoordinator:
             chunk_end = min(current_start + timedelta(days=max_days), end_time)
             _LOGGER.debug(f"Fetching {period} chunk from {current_start} to {chunk_end}")
 
+            # The API expects naive local timestamps
             data = await self._measurements_client.get_aggregated_measurements(
-                device.uuid, property_name, period, current_start, chunk_end, "sum"
+                device.uuid,
+                property_name,
+                period,
+                dt_util.as_local(current_start).replace(tzinfo=None),
+                dt_util.as_local(chunk_end).replace(tzinfo=None),
+                "sum",
             )
-            
+
             if data and "Values" in data:
                 statistics_data.extend(
-                    self._process_api_values(data["Values"], property_name, adjust_hour)
+                    self._process_api_values(data["Values"], property_name)
                 )
-            
+
             current_start = chunk_end
             
         _LOGGER.debug(f"Retrieved {len(statistics_data)} {period} data points")
@@ -236,7 +231,7 @@ class StatisticsCoordinator:
         self, device: CoCoDevice, property_name: str, start_time: datetime, end_time: datetime
     ) -> list[dict]:
         return await self._fetch_aggregated_data(
-            device, property_name, start_time, end_time, "hour", MAX_HOURLY_INTERVAL_DAYS, adjust_hour=True
+            device, property_name, start_time, end_time, "hour", MAX_HOURLY_INTERVAL_DAYS
         )
 
     def _build_statistic_entries(self, statistics_data: list[dict], initial_sum: float) -> list[StatisticData]:

--- a/custom_components/nhc2/statistics_coordinator.py
+++ b/custom_components/nhc2/statistics_coordinator.py
@@ -44,10 +44,10 @@ UNIT_CONVERSIONS = {
 # for the recorder.
 
 def align_to_hour(dt: datetime) -> datetime:
-    return dt_util.as_local(dt).replace(minute=0, second=0, microsecond=0)
+    return dt_util.as_utc(dt_util.as_local(dt).replace(minute=0, second=0, microsecond=0))
 
 def align_to_midnight(dt: datetime) -> datetime:
-    return dt_util.as_local(dt).replace(hour=0, minute=0, second=0, microsecond=0)
+    return dt_util.as_utc(dt_util.as_local(dt).replace(hour=0, minute=0, second=0, microsecond=0))
 
 class StatisticsCoordinator:
     def __init__(

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+asyncio_mode = auto

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 testpaths = tests
-asyncio_mode = auto
+# These tests mock hass; opt out of the pytest-homeassistant-custom-component
+# fixture harness so they also run in environments where it is installed.
+addopts = -p no:homeassistant

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,7 @@
 pytest
-pytest-homeassistant-custom-component
+# The tests mock hass, so only Home Assistant itself is needed (for dt_util),
+# not the full pytest-homeassistant-custom-component fixture harness.
+homeassistant>=2026.2
 freezegun
 paho-mqtt>=1.6.1
 pyjwt

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,5 @@
+pytest
+pytest-homeassistant-custom-component
+freezegun
+paho-mqtt>=1.6.1
+pyjwt

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the nhc2 custom integration."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Shared fixtures."""
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from homeassistant.util import dt as dt_util
+
+BRUSSELS = ZoneInfo("Europe/Brussels")
+
+
+@pytest.fixture(autouse=True)
+def brussels_timezone():
+    """Run every test with HA configured for Europe/Brussels."""
+    original = dt_util.DEFAULT_TIME_ZONE
+    dt_util.DEFAULT_TIME_ZONE = BRUSSELS
+    yield
+    dt_util.DEFAULT_TIME_ZONE = original

--- a/tests/test_statistics_coordinator.py
+++ b/tests/test_statistics_coordinator.py
@@ -45,11 +45,14 @@ class TestAlignment:
         aligned = align_to_hour(datetime(2026, 7, 15, 12, 30, 59, tzinfo=UTC))
         assert aligned == datetime(2026, 7, 15, 12, 0, tzinfo=UTC)
         assert aligned.astimezone(BRUSSELS).minute == 0
+        # returned as a UTC instant, aligned to the local hour boundary
+        assert aligned.utcoffset().total_seconds() == 0
 
     def test_align_to_midnight_uses_local_midnight(self):
         aligned = align_to_midnight(datetime(2026, 7, 15, 12, 30, tzinfo=UTC))
         # local midnight 2026-07-15 CEST == 2026-07-14 22:00 UTC
         assert aligned == datetime(2026, 7, 14, 22, 0, tzinfo=UTC)
+        assert aligned.utcoffset().total_seconds() == 0
 
     def test_align_to_midnight_uses_local_midnight_in_winter(self):
         aligned = align_to_midnight(datetime(2026, 1, 15, 12, 30, tzinfo=UTC))

--- a/tests/test_statistics_coordinator.py
+++ b/tests/test_statistics_coordinator.py
@@ -1,0 +1,225 @@
+"""Tests for the statistics coordinator's timestamp handling.
+
+The measurements API on the Connected Controller works in the
+controller's local time: request intervals are interpreted as local time
+and returned DateTime values are naive local period starts (verified
+against a live controller: a completed hourly bucket labeled 07:00 was
+returned at 06:07 UTC, which is only possible for local labels).
+
+These tests pin the local-time contract so the one-hour DST shift from
+issue #300 cannot regress.
+"""
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+from zoneinfo import ZoneInfo
+
+from freezegun import freeze_time
+
+from custom_components.nhc2.statistics_coordinator import (
+    StatisticsCoordinator,
+    align_to_hour,
+    align_to_midnight,
+)
+
+BRUSSELS = ZoneInfo("Europe/Brussels")
+UTC = timezone.utc
+
+
+def make_coordinator(measurements_client=None) -> StatisticsCoordinator:
+    return StatisticsCoordinator(
+        hass=MagicMock(),
+        gateway=MagicMock(),
+        measurements_client=measurements_client or MagicMock(),
+        config_entry=MagicMock(),
+    )
+
+
+def controller_label(true_hour_utc: datetime) -> str:
+    """Label a bucket the way the controller does: naive local period start."""
+    return true_hour_utc.astimezone(BRUSSELS).replace(tzinfo=None).isoformat()
+
+
+class TestAlignment:
+    def test_align_to_hour_uses_local_time(self):
+        aligned = align_to_hour(datetime(2026, 7, 15, 12, 30, 59, tzinfo=UTC))
+        assert aligned == datetime(2026, 7, 15, 12, 0, tzinfo=UTC)
+        assert aligned.astimezone(BRUSSELS).minute == 0
+
+    def test_align_to_midnight_uses_local_midnight(self):
+        aligned = align_to_midnight(datetime(2026, 7, 15, 12, 30, tzinfo=UTC))
+        # local midnight 2026-07-15 CEST == 2026-07-14 22:00 UTC
+        assert aligned == datetime(2026, 7, 14, 22, 0, tzinfo=UTC)
+
+    def test_align_to_midnight_uses_local_midnight_in_winter(self):
+        aligned = align_to_midnight(datetime(2026, 1, 15, 12, 30, tzinfo=UTC))
+        # local midnight 2026-01-15 CET == 2026-01-14 23:00 UTC
+        assert aligned == datetime(2026, 1, 14, 23, 0, tzinfo=UTC)
+
+
+class TestProcessApiValues:
+    def test_naive_timestamp_is_local_in_summer(self):
+        coordinator = make_coordinator()
+        result = coordinator._process_api_values(
+            [{"DateTime": "2026-07-15T14:00:00", "Value": 5.0}], "ElectricalEnergy"
+        )
+        # 14:00 CEST == 12:00 UTC
+        assert result == [
+            {"start": datetime(2026, 7, 15, 12, 0, tzinfo=UTC), "value": 5.0}
+        ]
+
+    def test_naive_timestamp_is_local_in_winter(self):
+        coordinator = make_coordinator()
+        result = coordinator._process_api_values(
+            [{"DateTime": "2026-01-15T14:00:00", "Value": 5.0}], "ElectricalEnergy"
+        )
+        # 14:00 CET == 13:00 UTC
+        assert result == [
+            {"start": datetime(2026, 1, 15, 13, 0, tzinfo=UTC), "value": 5.0}
+        ]
+
+    def test_aware_timestamp_is_respected(self):
+        coordinator = make_coordinator()
+        result = coordinator._process_api_values(
+            [{"DateTime": "2026-07-15T14:00:00+00:00", "Value": 1.0}],
+            "ElectricalEnergy",
+        )
+        assert result[0]["start"] == datetime(2026, 7, 15, 14, 0, tzinfo=UTC)
+
+    def test_water_volume_conversion(self):
+        coordinator = make_coordinator()
+        result = coordinator._process_api_values(
+            [{"DateTime": "2026-07-15T14:00:00", "Value": 0.25}], "WaterVolume"
+        )
+        assert result[0]["value"] == 250
+
+    def test_incomplete_entries_are_skipped(self):
+        coordinator = make_coordinator()
+        result = coordinator._process_api_values(
+            [
+                {"DateTime": "2026-07-15T14:00:00"},
+                {"Value": 1.0},
+                {"DateTime": "2026-07-15T15:00:00", "Value": None},
+            ],
+            "ElectricalEnergy",
+        )
+        assert result == []
+
+
+class TestNoHourShift:
+    """Regression tests for issue #300: buckets must land in their true hour."""
+
+    def _round_trip_mismatches(self, start_utc: datetime, hours: int) -> list:
+        coordinator = make_coordinator()
+        mismatches = []
+        for i in range(hours):
+            true_hour = start_utc + timedelta(hours=i)
+            result = coordinator._process_api_values(
+                [{"DateTime": controller_label(true_hour), "Value": 1.0}],
+                "ElectricalEnergy",
+            )
+            if result[0]["start"] != true_hour:
+                mismatches.append((true_hour, result[0]["start"]))
+        return mismatches
+
+    def test_winter_week_round_trips_exactly(self):
+        assert not self._round_trip_mismatches(
+            datetime(2027, 1, 10, 0, tzinfo=UTC), 168
+        )
+
+    def test_summer_week_round_trips_exactly(self):
+        assert not self._round_trip_mismatches(
+            datetime(2027, 7, 11, 0, tzinfo=UTC), 168
+        )
+
+    def test_spring_forward_round_trips_exactly(self):
+        # DST starts 2027-03-28 02:00 CET -> 03:00 CEST; the skipped local
+        # hour never appears as a label, so every bucket maps back exactly.
+        assert not self._round_trip_mismatches(
+            datetime(2027, 3, 27, 20, tzinfo=UTC), 12
+        )
+
+    def test_fall_back_has_exactly_one_ambiguous_hour(self):
+        # DST ends 2026-10-25 03:00 CEST -> 02:00 CET: the local hour 02:00
+        # occurs twice but the API's naive label cannot distinguish the two
+        # passes. Exactly one hour per year is ambiguous; anything more than
+        # that single known collision is a regression.
+        mismatches = self._round_trip_mismatches(
+            datetime(2026, 10, 24, 20, tzinfo=UTC), 12
+        )
+        assert mismatches == [
+            (
+                datetime(2026, 10, 25, 1, 0, tzinfo=UTC),  # second 02:00 local
+                datetime(2026, 10, 25, 0, 0, tzinfo=UTC),  # mapped to the first
+            )
+        ]
+
+
+class TestRequestWindow:
+    def test_fetch_sends_naive_local_interval(self):
+        client = MagicMock()
+        client.get_aggregated_measurements = AsyncMock(return_value=None)
+        coordinator = make_coordinator(client)
+
+        device = MagicMock()
+        device.uuid = "uuid"
+        asyncio.run(
+            coordinator._fetch_aggregated_data(
+                device,
+                "ElectricalEnergy",
+                datetime(2026, 7, 15, 10, 0, tzinfo=UTC),
+                datetime(2026, 7, 15, 12, 0, tzinfo=UTC),
+                "hour",
+                63,
+            )
+        )
+
+        args = client.get_aggregated_measurements.await_args.args
+        interval_start, interval_end = args[3], args[4]
+        # 10:00/12:00 UTC == 12:00/14:00 CEST, sent naive
+        assert interval_start == datetime(2026, 7, 15, 12, 0)
+        assert interval_start.tzinfo is None
+        assert interval_end == datetime(2026, 7, 15, 14, 0)
+        assert interval_end.tzinfo is None
+
+
+class TestCalculateTimeRange:
+    @freeze_time("2026-07-15 10:30:00+00:00")
+    def test_recent_import_has_no_one_hour_fudge(self):
+        coordinator = make_coordinator()
+        statistic_id = "nhc2:test_electricalenergy"
+        last_start = datetime(2026, 7, 15, 8, 0, tzinfo=UTC)
+        last_stats = {statistic_id: [{"start": last_start.timestamp(), "sum": 1.0}]}
+
+        start_time, end_time = coordinator._calculate_time_range(
+            statistic_id, last_stats, longterm=False
+        )
+
+        # resume exactly one hour after the last stored bucket ...
+        assert start_time == last_start + timedelta(hours=1)
+        # ... up to the start of the current (incomplete) local hour
+        assert end_time == datetime(2026, 7, 15, 10, 0, tzinfo=UTC)
+
+    @freeze_time("2026-07-15 10:30:00+00:00")
+    def test_recent_import_without_history_starts_two_months_back(self):
+        coordinator = make_coordinator()
+        start_time, end_time = coordinator._calculate_time_range(
+            "nhc2:test_electricalenergy", {}, longterm=False
+        )
+
+        # local midnight 60 days ago: 2026-05-16 00:00 CEST == 05-15 22:00 UTC
+        assert start_time == datetime(2026, 5, 15, 22, 0, tzinfo=UTC)
+        assert end_time == datetime(2026, 7, 15, 10, 0, tzinfo=UTC)
+
+    @freeze_time("2026-07-15 10:30:00+00:00")
+    def test_no_new_data_returns_none(self):
+        coordinator = make_coordinator()
+        statistic_id = "nhc2:test_electricalenergy"
+        # last bucket is the most recent complete hour -> nothing to fetch
+        last_start = datetime(2026, 7, 15, 9, 0, tzinfo=UTC)
+        last_stats = {statistic_id: [{"start": last_start.timestamp(), "sum": 1.0}]}
+
+        assert (
+            coordinator._calculate_time_range(statistic_id, last_stats, longterm=False)
+            is None
+        )


### PR DESCRIPTION
The measurements API works in the controller's local time: request intervals are interpreted as local time (a UTC offset in the string is ignored) and returned `DateTime` values are naive local period starts.

The importer treated those response timestamps as UTC and compensated with a hardcoded `-1h` on the hourly path, plus a `+1h` shift on the request window. Those offsets only cancel out when the local offset is exactly UTC+1, i.e. CET winter time. Under CEST every hourly statistic lands one hour late, which is what shows up in the Energy dashboard as consumption lagging by an hour, and can produce negative bars around steep changes. The daily path was off by the full local offset.

Rather than compensating, this makes the timezone handling explicit:

- interpret naive response timestamps in HA's configured timezone and convert to UTC for the recorder
- send request intervals to the API as naive local timestamps
- align interval boundaries to local hour/midnight
- drop the `+1h` request-window shift and the `adjust_hour=-1h` correction

Winter behaviour is unchanged, since the old offsets cancelled out to exactly this. Summer imports now land in the correct hour.

Two things worth knowing for anyone upgrading: statistics already imported during summer with the old code stay one hour late, and there is a one-time one-hour gap at the changeover from shifted to correct buckets.

Also adds unit tests for the timestamp handling and a `pytest` job to the validate workflow.

Fixes #300
